### PR TITLE
Changes to selected test processing

### DIFF
--- a/src/nunit-gui/Model/ITestItem.cs
+++ b/src/nunit-gui/Model/ITestItem.cs
@@ -32,7 +32,7 @@ namespace NUnit.Gui.Model
     /// <summary>
     /// ITestItem is the common interface shared by TestNodes
     /// and TestGroups and allows either to be selected in
-    /// the settingsServiceServiceService.
+    /// the tree.
     /// </summary>
     public interface ITestItem
     {

--- a/src/nunit-gui/Model/ITestModel.cs
+++ b/src/nunit-gui/Model/ITestModel.cs
@@ -27,47 +27,35 @@ using NUnit.Engine;
 namespace NUnit.Gui.Model
 {
     /// <summary>
-    /// The delegate for all events related to running tests
+    /// Delegates for all events related to the model
     /// </summary>
     public delegate void TestEventHandler(TestEventArgs args);
+    public delegate void RunStartingEventHandler(RunStartingEventArgs args);
+    public delegate void TestNodeEventHandler(TestNodeEventArgs args);
+    public delegate void TestResultEventHandler(TestResultEventArgs args);
+    public delegate void TestItemEventHandler(TestItemEventArgs args);
 
     public interface ITestModel : IServiceLocator, System.IDisposable
     {
         #region Events
 
         // Events related to loading and unloading tests.
-        //event TestEventHandler TestLoading;
-        event TestEventHandler TestLoaded;
-
-        //event TestEventHandler TestReloading;
-        event TestEventHandler TestReloaded;
-
-        //event TestEventHandler TestUnloading;
+        event TestNodeEventHandler TestLoaded;
+        event TestNodeEventHandler TestReloaded;
         event TestEventHandler TestUnloaded;
 
-        // Events related to a running a set of tests
-        event TestEventHandler RunStarting;
-        event TestEventHandler SuiteStarting;
-        event TestEventHandler TestStarting;
+        // Events related to running tests
+        event RunStartingEventHandler RunStarting;
+        event TestNodeEventHandler SuiteStarting;
+        event TestNodeEventHandler TestStarting;
 
-        event TestEventHandler RunFinished;
-        event TestEventHandler SuiteFinished;
-        event TestEventHandler TestFinished;
+        event TestResultEventHandler RunFinished;
+        event TestResultEventHandler SuiteFinished;
+        event TestResultEventHandler TestFinished;
 
-        event TestEventHandler RunFailed;
-
-        /// <summary>
-        /// An unhandled exception was thrown during a test run,
-        /// and it cannot be associated with a particular test failure.
-        /// </summary>
-        event TestEventHandler TestException;
-
-        /// <summary>
-        /// Console Out/Error
-        /// </summary>
-        event TestEventHandler TestOutput;
-
-        event System.EventHandler SelectedTestChanged;
+        // Event used to broadcast a change in the selected
+        // item, so that all presenters may be notified.
+        event TestItemEventHandler SelectedItemChanged;
 
         #endregion
 
@@ -88,13 +76,7 @@ namespace NUnit.Gui.Model
         // See if a test is running
         bool IsTestRunning { get; }
 
-        //// Our last test results
-        //TestResult TestResult { get; }
-
         bool HasResults { get; }
-
-        // The currently selected test item
-        ITestItem SelectedTest { get; set; }
 
         Settings.SettingsModel Settings { get; }
 
@@ -124,21 +106,20 @@ namespace NUnit.Gui.Model
         // Reload current TestPackage
         void ReloadTests();
 
+        // Run all the tests
+        void RunAllTests();
+
         // Run just the specified ITestItem
         void RunTests(ITestItem testItem);
-
-        // Run the currently selected test or group
-        void RunSelectedTest();
-
-        // Run the tests in the current TestPackage
-        // using the provided filter.
-        void RunTests( NUnit.Engine.TestFilter filter );
 
         // Cancel the running test
         void CancelTestRun();
 
         // Get the result for a test if available
         ResultNode GetResultForTest(TestNode testNode);
+
+        // Broadcast event when SelectedTestItem changes
+        void NotifySelectedItemChanged(ITestItem testItem);
         
         #endregion
     }

--- a/src/nunit-gui/Model/TestEventArgs.cs
+++ b/src/nunit-gui/Model/TestEventArgs.cs
@@ -36,34 +36,54 @@ namespace NUnit.Gui.Model
             this.Action = action;
         }
 
-        public TestEventArgs(TestAction action, TestNode test)
+        public TestAction Action { get; private set; }
+    }
+
+    public class TestNodeEventArgs : TestEventArgs
+    {
+        public TestNodeEventArgs(TestAction action, TestNode test)
+            : base(action)
         {
             if (test == null)
                 throw new ArgumentNullException("test");
 
-            this.Action = action;
-            this.Test = test;
+            Test = test;
         }
 
-        public TestEventArgs(TestAction action, ResultNode result)
+        public TestNode Test { get; private set; }
+    }
+
+    public class RunStartingEventArgs : TestEventArgs
+    {
+        public RunStartingEventArgs(int testCount)
+            : base(TestAction.RunStarting)
+        {
+            TestCount = testCount;
+        }
+
+        public int TestCount { get; private set; }
+    }
+
+    public class TestResultEventArgs : TestEventArgs
+    {
+        public TestResultEventArgs(TestAction action, ResultNode result) : base(action)
         {
             if (result == null)
                 throw new ArgumentNullException("result");
 
-            this.Action = action;
-            this.Result = result;
+            Result = result;
         }
 
-        public TestEventArgs(TestAction action, int testCount)
-        {
-            this.Action = action;
-            this.TestCount = testCount;
-        }
-
-        public TestAction Action { get; private set; }
-        public TestNode Test { get; private set; }
         public ResultNode Result { get; private set; }
-        public int TestCount { get; private set; }
-        //public TestOutput TestOutput { get; private set; }
+    }
+
+    public class TestItemEventArgs : EventArgs
+    {
+        public TestItemEventArgs(ITestItem testItem)
+        {
+            TestItem = testItem;
+        }
+
+        public ITestItem TestItem { get; private set; }
     }
 }

--- a/src/nunit-gui/Presenters/MainPresenter.cs
+++ b/src/nunit-gui/Presenters/MainPresenter.cs
@@ -58,8 +58,6 @@ namespace NUnit.Gui.Presenters
             _model.TestReloaded += (ea) => InitializeMainMenu();
             _model.RunStarting += (ea) => InitializeMainMenu();
             _model.RunFinished += (ea) => InitializeMainMenu();
-            _model.RunFailed += OnFailure;
-            _model.TestException += OnFailure;
 
             // View Events
             _view.Load += MainForm_Load;
@@ -107,11 +105,6 @@ namespace NUnit.Gui.Presenters
 
             // Project Menu
             _view.ProjectMenu.Enabled = _view.ProjectMenu.Visible = _model.HasTests;
-        }
-
-        private void OnFailure(TestEventArgs ea)
-        {
-            MessageBox.Show(ea.Test.Xml.OuterXml, ea.Action.ToString());
         }
 
         #endregion

--- a/src/nunit-gui/Presenters/StatusBarPresenter.cs
+++ b/src/nunit-gui/Presenters/StatusBarPresenter.cs
@@ -57,17 +57,16 @@ namespace NUnit.Gui.Presenters
             _model.TestUnloaded += OnTestUnloaded;
             _model.RunStarting += OnRunStarting;
             _model.RunFinished += OnRunFinished;
-            _model.RunFailed += OnRunFailed;
             _model.TestStarting += OnTestStarting;
             _model.TestFinished += OnTestFinished;
         }
 
-        private void OnTestLoaded(TestEventArgs ea)
+        private void OnTestLoaded(TestNodeEventArgs ea)
         {
             _view.Initialize("Ready", ea.Test.TestCount);
         }
 
-        private void OnTestReloaded(TestEventArgs ea)
+        private void OnTestReloaded(TestNodeEventArgs ea)
         {
             _view.Initialize("Reloaded", ea.Test.TestCount);
         }
@@ -77,27 +76,22 @@ namespace NUnit.Gui.Presenters
             _view.Initialize("Unloaded");
         }
 
-        private void OnRunStarting(TestEventArgs ea)
+        private void OnRunStarting(RunStartingEventArgs ea)
         {
             _view.RunStarting(ea.TestCount);
         }
 
-        private void OnRunFinished(TestEventArgs ea)
+        private void OnRunFinished(TestResultEventArgs ea)
         {
             _view.RunFinished(ea.Result.Duration);
         }
 
-        private void OnRunFailed(TestEventArgs ea)
-        {
-            _view.SetStatus("Run Failed");
-        }
-
-        public void OnTestStarting(TestEventArgs e)
+        public void OnTestStarting(TestNodeEventArgs e)
         {
             _view.SetStatus("Running : " + e.Test.Name);
         }
 
-        private void OnTestFinished(TestEventArgs ea)
+        private void OnTestFinished(TestResultEventArgs ea)
         {
             var result = ea.Result.Outcome;
             if (result.Status == TestStatus.Passed)

--- a/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
@@ -38,6 +38,8 @@ namespace NUnit.Gui.Presenters
         private int _maxY = 0;
         private int _nextY = 4;
 
+        private ITestItem _selectedItem;
+
         public TestPropertiesPresenter(ITestPropertiesView view, ITestModel model)
         {
             _view = view;
@@ -54,16 +56,21 @@ namespace NUnit.Gui.Presenters
             _model.TestReloaded += (ea) => _view.Visible = true;
             _model.TestUnloaded += (ea) => _view.Visible = false;
             _model.RunFinished += (ea) => DisplayTestProperties();
-            _model.SelectedTestChanged += (s, ea) => DisplayTestProperties();
-            _view.DisplayHiddenPropertiesChanged += DisplayTestProperties;
+            _model.SelectedItemChanged += (ea) => OnSelectedItemChanged(ea.TestItem);
+            _view.DisplayHiddenPropertiesChanged += () => DisplayTestProperties();
+        }
+
+        private void OnSelectedItemChanged(ITestItem testItem)
+        {
+            _selectedItem = testItem;
+            DisplayTestProperties();
         }
 
         private void DisplayTestProperties()
         {
             // TODO: Insert checks for errors in the XML
 
-            var testItem = _model.SelectedTest;
-            var testNode = testItem as TestNode;
+            var testNode = _selectedItem as TestNode;
             var resultNode = _model.GetResultForTest(testNode);
 
             _view.TestPanel.Visible = testNode != null;
@@ -113,9 +120,9 @@ namespace NUnit.Gui.Presenters
 
                 _view.ResumeLayout();
             }
-            else if (testItem != null)
+            else if (_selectedItem != null)
             {
-                _view.Header = testItem.Name;
+                _view.Header = _selectedItem.Name;
             }
         }
 

--- a/src/nunit-gui/Presenters/TreeViewPresenter.cs
+++ b/src/nunit-gui/Presenters/TreeViewPresenter.cs
@@ -42,6 +42,8 @@ namespace NUnit.Gui.Presenters
 
         private DisplayStrategy _strategy;
 
+        private ITestItem _selectedTestItem;
+
         private Dictionary<string, TreeNode> _nodeIndex = new Dictionary<string, TreeNode>();
 
         #region Constructor
@@ -100,18 +102,22 @@ namespace NUnit.Gui.Presenters
             _view.RunContextCommand.Execute += () => _model.RunTests(_view.Tree.ContextNode.Tag as ITestItem);
 
             // Node selected in tree
-            _view.Tree.SelectedNodeChanged += (tn) => _model.SelectedTest = tn.Tag as ITestItem;
+            _view.Tree.SelectedNodeChanged += (tn) =>
+            {
+                _selectedTestItem = tn.Tag as ITestItem;
+                _model.NotifySelectedItemChanged(_selectedTestItem);
+            };
 
             // Run button and dropdowns
             _view.RunButton.Execute += () =>
             {
                 // Necessary test because we don't disable the button click
                 if (_model.HasTests && !_model.IsTestRunning)
-                    _model.RunTests(TestFilter.Empty);
+                    _model.RunAllTests();
             };
-            _view.RunAllCommand.Execute += () => _model.RunTests(TestFilter.Empty);
+            _view.RunAllCommand.Execute += () => _model.RunAllTests();
             _view.RunSelectedCommand.Execute += () => RunSelectedTests();
-            _view.RunFailedCommand.Execute += () => _model.RunTests(TestFilter.Empty); // NYI
+            _view.RunFailedCommand.Execute += () => _model.RunAllTests(); // NYI
             _view.StopRunCommand.Execute += () => _model.CancelTestRun();
 
             // Change of display format
@@ -134,7 +140,7 @@ namespace NUnit.Gui.Presenters
             //    }
             //}
             
-            _model.RunSelectedTest();
+            _model.RunTests(_selectedTestItem);
         }
 
         private void InitializeRunCommands()

--- a/src/nunit-gui/Presenters/XmlPresenter.cs
+++ b/src/nunit-gui/Presenters/XmlPresenter.cs
@@ -36,6 +36,8 @@ namespace NUnit.Gui.Presenters
         private readonly IXmlView _view;
         private readonly ITestModel _model;
 
+        private ITestItem _selectedItem;
+
         public XmlPresenter(IXmlView view, ITestModel model)
         {
             _view = view;
@@ -52,13 +54,18 @@ namespace NUnit.Gui.Presenters
             _model.TestReloaded += (ea) => _view.Visible = true;
             _model.TestUnloaded += (ea) => _view.Visible = false;
             _model.RunFinished += (ea) => DisplayXml();
-            _model.SelectedTestChanged += (s, ea) => DisplayXml();
+            _model.SelectedItemChanged += (ea) => OnSelectedItemChanged(ea.TestItem);
+        }
+
+        private void OnSelectedItemChanged(ITestItem testItem)
+        {
+            _selectedItem = testItem;
+            DisplayXml();
         }
 
         private void DisplayXml()
         {
-            var testItem = _model.SelectedTest;
-            var testNode = testItem as TestNode;
+            var testNode = _selectedItem as TestNode;
 
             _view.XmlPanel.Visible = testNode != null;
 
@@ -69,11 +76,10 @@ namespace NUnit.Gui.Presenters
                 _view.TestXml = testNode.Xml;
                 _view.ResumeLayout();
             }
-            else if (testItem != null)
+            else if (_selectedItem != null)
             {
-                _view.Header = testItem.Name;
+                _view.Header = _selectedItem.Name;
             }
         }
-
     }
 }

--- a/src/tests/Model/TestModelTests.cs
+++ b/src/tests/Model/TestModelTests.cs
@@ -66,7 +66,7 @@ namespace NUnit.Gui.Model
         [Test]
         public void CheckStateAfterRunningTests()
         {
-            _model.RunTests(TestFilter.Empty);
+            _model.RunAllTests();
 
             Assert.That(_model.HasTests, "HasTests");
             Assert.NotNull(_model.Tests, "Tests");
@@ -76,7 +76,7 @@ namespace NUnit.Gui.Model
         [Test]
         public void CheckStateAfterUnloading()
         {
-            _model.RunTests(TestFilter.Empty);
+            _model.RunAllTests();
 
             //Assert.False(_model.HasTests, "HasTests");
             //Assert.Null(_model.Tests, "Tests");

--- a/src/tests/Presenters/Main/WhenTestRunBegins.cs
+++ b/src/tests/Presenters/Main/WhenTestRunBegins.cs
@@ -35,7 +35,7 @@ namespace NUnit.Gui.Presenters.Main
         {
             Model.HasTests.Returns(true);
             Model.IsTestRunning.Returns(true);
-            Model.RunStarting += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.RunStarting, 1234));
+            Model.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
         }
 
 #if NYI

--- a/src/tests/Presenters/Main/WhenTestRunCompletes.cs
+++ b/src/tests/Presenters/Main/WhenTestRunCompletes.cs
@@ -23,7 +23,6 @@
 
 using NSubstitute;
 using NUnit.Framework;
-using System.Xml;
 
 namespace NUnit.Gui.Presenters.Main
 {
@@ -38,10 +37,8 @@ namespace NUnit.Gui.Presenters.Main
             Model.HasTests.Returns(true);
             Model.IsTestRunning.Returns(false);
 
-            XmlDocument doc = new XmlDocument();
-            doc.LoadXml("<test-suite/>");
-            TestNode resultNode = new TestNode(doc.FirstChild);
-            Model.RunFinished += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.RunFinished, resultNode));
+            var resultNode = new ResultNode("<test-suite/>");
+            Model.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.RunFinished, resultNode));
         }
 
 #if NYI

--- a/src/tests/Presenters/Main/WhenTestsAreLoaded.cs
+++ b/src/tests/Presenters/Main/WhenTestsAreLoaded.cs
@@ -42,7 +42,7 @@ namespace NUnit.Gui.Presenters.Main
             doc.LoadXml("<test-suite id='1'/>");
             TestNode testNode = new TestNode(doc.FirstChild);
             Model.Tests.Returns(testNode);
-            Model.TestReloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestReloaded, testNode));
+            Model.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, testNode));
         }
 
 #if NYI

--- a/src/tests/Presenters/Main/WhenTestsAreReloaded.cs
+++ b/src/tests/Presenters/Main/WhenTestsAreReloaded.cs
@@ -42,7 +42,7 @@ namespace NUnit.Gui.Presenters.Main
             doc.LoadXml("<test-suite id='1'/>");
             TestNode testNode = new TestNode(doc.FirstChild);
             Model.Tests.Returns(testNode);
-            Model.TestLoaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestLoaded, testNode));
+            Model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
         }
 
 #if NYI

--- a/src/tests/Presenters/ProgressBarPresenterTests.cs
+++ b/src/tests/Presenters/ProgressBarPresenterTests.cs
@@ -60,7 +60,9 @@ namespace NUnit.Gui.Presenters
         {
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
-            _model.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestLoaded));
+
+            var testNode = new TestNode("<test-suite id='1' testcasecount='1234'/>");
+            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
 
             _view.Received().Initialize(100);
         }
@@ -80,7 +82,9 @@ namespace NUnit.Gui.Presenters
         {
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
-            _model.TestUnloaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestReloaded));
+
+            var testNode = new TestNode("<test-suite id='1' testcasecount='1234'/>");
+            _model.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, testNode));
 
             _view.Received().Initialize(100);
         }
@@ -90,7 +94,7 @@ namespace NUnit.Gui.Presenters
         {
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(true);
-            _model.RunStarting += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.RunStarting, 1234));
+            _model.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
 
             _view.Received().Initialize(1234);
         }
@@ -99,9 +103,9 @@ namespace NUnit.Gui.Presenters
         public void WhenTestCaseCompletes_ProgressIsIncremented()
         {
             int priorValue = _view.Progress;
-            var result = new ResultNode(XmlHelper.CreateXmlNode("<test-case id='1'/>"));
+            var result = new ResultNode("<test-case id='1'/>");
 
-            _model.TestFinished += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestFinished, result));
+            _model.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
 
             Assert.That(_view.Progress, Is.EqualTo(priorValue + 1));
         }
@@ -110,9 +114,9 @@ namespace NUnit.Gui.Presenters
         public void WhenTestSuiteCompletes_ProgressIsNotIncremented()
         {
             int priorValue = _view.Progress;
-            var result = new ResultNode(XmlHelper.CreateXmlNode("<test-suite id='1'/>"));
+            var result = new ResultNode("<test-suite id='1'/>");
 
-            _model.SuiteFinished += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.SuiteFinished, result));
+            _model.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.SuiteFinished, result));
 
             Assert.That(_view.Progress, Is.EqualTo(priorValue));
         }
@@ -166,8 +170,8 @@ namespace NUnit.Gui.Presenters
 
             _model.HasTests.Returns(true);
             _model.Tests.Returns(result);
-            _model.TestLoaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestLoaded, result));
-            _model.TestFinished += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestFinished, result));
+            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, result));
+            _model.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
 
             Assert.That(_view.Status, Is.EqualTo(expectedStatus));
         }

--- a/src/tests/Presenters/StatusBarPresenterTests.cs
+++ b/src/tests/Presenters/StatusBarPresenterTests.cs
@@ -81,7 +81,7 @@ namespace NUnit.Gui.Presenters
         {
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(true);
-            _model.RunStarting += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.RunStarting, 1234));
+            _model.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
 
             _view.Received().RunStarting(1234);
         }
@@ -91,7 +91,7 @@ namespace NUnit.Gui.Presenters
         {
             var result = new ResultNode(XmlHelper.CreateXmlNode("<test-case id='1'/>"));
 
-            _model.TestFinished += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestFinished, result));
+            _model.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
 
             _view.Received().RecordSuccess();
         }

--- a/src/tests/Presenters/TestTree/CommandTests.cs
+++ b/src/tests/Presenters/TestTree/CommandTests.cs
@@ -39,28 +39,33 @@ namespace NUnit.Gui.Presenters.TestTree
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
             _view.RunButton.Execute += Raise.Event<CommandHandler>();
-            _model.Received().RunTests(TestFilter.Empty);
+            _model.Received().RunAllTests();
         }
 
         [Test]
         public void ToolStrip_RunAllCommand_RunsAllTests()
         {
             _view.RunAllCommand.Execute += Raise.Event<CommandHandler>();
-            _model.Received().RunTests(TestFilter.Empty);
+            _model.Received().RunAllTests();
         }
 
         [Test]
         public void ToolStrip_RunSelectedCommand_RunsSelectedTest()
         {
+            var testNode = new TestNode("<test-case id='123'/>");
+            var treeNode = new TreeNode("test");
+            treeNode.Tag = testNode;
+
+            _view.Tree.SelectedNodeChanged += Raise.Event<TreeNodeActionHandler>(treeNode);
             _view.RunSelectedCommand.Execute += Raise.Event<CommandHandler>();
-            _model.Received().RunSelectedTest();
+            _model.Received().RunTests(testNode);
         }
 
         [Test]
         public void ToolStrip_RunFailedCommand_RunsAllTests()
         {
             _view.RunFailedCommand.Execute += Raise.Event<CommandHandler>();
-            _model.Received().RunTests(TestFilter.Empty);
+            _model.Received().RunAllTests();
         }
 
         [Test]

--- a/src/tests/Presenters/TestTree/WhenTestRunBegins.cs
+++ b/src/tests/Presenters/TestTree/WhenTestRunBegins.cs
@@ -36,7 +36,7 @@ namespace NUnit.Gui.Presenters.TestTree
             _model.IsPackageLoaded.Returns(true);
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(true);
-            _model.RunStarting += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.RunStarting, 1234));
+            _model.RunStarting += Raise.Event<RunStartingEventHandler>(new RunStartingEventArgs(1234));
         }
 
         [Test]

--- a/src/tests/Presenters/TestTree/WhenTestRunCompletes.cs
+++ b/src/tests/Presenters/TestTree/WhenTestRunCompletes.cs
@@ -41,7 +41,7 @@ namespace NUnit.Gui.Presenters.TestTree
 
             var resultNode = new ResultNode("<test-suite/>");
 
-            _model.RunFinished += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.RunFinished, resultNode));
+            _model.RunFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.RunFinished, resultNode));
         }
 
 
@@ -73,7 +73,7 @@ namespace NUnit.Gui.Presenters.TestTree
         public void RunAllMenuItemRunsAllTests()
         {
             _view.RunAllCommand.Execute += Raise.Event<CommandHandler>();
-            _model.Received().RunTests(NUnit.Engine.TestFilter.Empty);
+            _model.Received().RunAllTests();
         }
     }
 }

--- a/src/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
+++ b/src/tests/Presenters/TestTree/WhenTestsAreLoaded.cs
@@ -40,7 +40,7 @@ namespace NUnit.Gui.Presenters.TestTree
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
 
-            _model.TestLoaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestLoaded, new TestNode("<test-run/>")));
+            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, new TestNode("<test-run/>")));
         }
 
         [Test]

--- a/src/tests/Presenters/TestTree/WhenTestsAreReloaded.cs
+++ b/src/tests/Presenters/TestTree/WhenTestsAreReloaded.cs
@@ -34,13 +34,13 @@ namespace NUnit.Gui.Presenters.TestTree
     public class WhenTestsAreReloaded : TestTreePresenterTestBase
     {
         [SetUp]
-        public void SimulateTesReload()
+        public void SimulateTestReload()
         {
             _model.IsPackageLoaded.Returns(true);
             _model.HasTests.Returns(true);
             _model.IsTestRunning.Returns(false);
 
-            _model.TestLoaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestReloaded, new TestNode("<test-run/>")));
+            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, new TestNode("<test-run/>")));
         }
 
         [Test]

--- a/src/tests/Presenters/TreeViewPresenterTests.cs
+++ b/src/tests/Presenters/TreeViewPresenterTests.cs
@@ -98,8 +98,8 @@ namespace NUnit.Gui.Presenters
 
             //var treeNode = _adapter.MakeTreeNode(result);
             //_adapter.NodeIndex[suiteResult.Id] = treeNode;
-            _model.TestLoaded += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestLoaded, testNode));
-            _model.TestFinished += Raise.Event<TestEventHandler>(new TestEventArgs(TestAction.TestFinished, resultNode));
+            _model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
+            _model.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, resultNode));
 
             _view.Tree.Received().SetImageIndex(Arg.Any<TreeNode>(), expectedIndex);
         }


### PR DESCRIPTION
The selected test node in the tree did not really belong in the model as it's part of the presentation logic. This PR  takes care of the problem.

* Created more event handler delegates and event argument types, so events will be a bit more type-safe than they were. Discovered some errors in the code in the process.

* Eliminated SelectedTest as a model property.

* Added a model method NotifySelectedTestItemChanged, which causes the model to re-broadcast a change discovered by one of the presenters so that other presenters can handle it.

* Each presenter that uses the selected item independently maintains a field with the current selection.

I plan to follow the rule of three here. That is, if we find a second event that needs to be handled by multiple presenters, I'll just add an event and notify method to the model. But once we find a third one, I would expect to add a subsystem that allows registering events to be broadcast.