### PR TITLE
Use only private copy of engine.

### DIFF
--- a/src/nunit-gui/Program.cs
+++ b/src/nunit-gui/Program.cs
@@ -62,7 +62,7 @@ namespace NUnit.Gui
                 return;
             }
 
-            var testEngine = TestEngineActivator.CreateInstance();
+            var testEngine = TestEngineActivator.CreateInstance(true);
             if (options.InternalTraceLevel != null)
                 testEngine.InternalTraceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), options.InternalTraceLevel);
 


### PR DESCRIPTION
This fixes issue #93 by forcing the Gui to use the bundled copy of the engine.