### PR TITLE
Bug Fix when viewing by category

### DIFF
--- a/src/nunit-gui/Presenters/CategoryGrouping.cs
+++ b/src/nunit-gui/Presenters/CategoryGrouping.cs
@@ -92,8 +92,9 @@ namespace NUnit.Gui.Presenters
                 {
                     group = new TestGroup(groupName);
                     Groups.Add(group);
-                    groups.Add(group);
                 }
+                
+                groups.Add(group);
             }
 
             if (groups.Count == 0)


### PR DESCRIPTION
When viewing testcases by category, only the first test of each case gets listed under the correct category, everything else defaults to Category None (via the groups.Add(Groups[0]) line above), even if an existing group was found with the required name.