### PR TITLE
When initializing ResultNode use CultureInfo.InvariantCulture for parsing `duration` attribute value

### DIFF
--- a/src/nunit-gui/Model/ResultNode.cs
+++ b/src/nunit-gui/Model/ResultNode.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.Xml;
 using NUnit.Engine;
@@ -54,7 +55,7 @@ namespace NUnit.Gui.Model
             AssertCount = GetAttribute("asserts", 0);
             var duration = GetAttribute("duration");
             Duration = duration != null
-                ? double.Parse(duration)
+                ? double.Parse(duration, CultureInfo.InvariantCulture)
                 : 0.0;
         }
 

--- a/src/tests/Model/ResultNodeTests.cs
+++ b/src/tests/Model/ResultNodeTests.cs
@@ -1,0 +1,42 @@
+// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Framework;
+
+namespace NUnit.Gui.Model
+{
+    [TestFixture]
+    public class ResultNodeTests
+    {
+        [Test]
+        [SetCulture("fr-FR")]
+        public void CreateResultNode_CurrentCultureWithDifferentDelimiter_DoesNotThrowException()
+        {
+            TestDelegate newResultNode = () =>
+            {
+                var resultNode = new ResultNode("<test-case duration='0.000'/>");
+            };
+            Assert.DoesNotThrow(newResultNode);
+        }
+    }
+}

--- a/src/tests/nunit-gui.tests.csproj
+++ b/src/tests/nunit-gui.tests.csproj
@@ -64,6 +64,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Model\ResultNodeTests.cs" />
     <Compile Include="Model\ResultStateTests.cs" />
     <Compile Include="Model\TestModelTests.cs" />
     <Compile Include="Model\TestSelectionTests.cs" />


### PR DESCRIPTION
Fixes #117.

Inside `InitializeResultProperties` changed to `double.Parse` overload with culture parameter usage, so it will parse using `CultureInfo.InvariantCulture` and thus won't throw `System.FormatException` on systems that use different from '.' (dot) decimal delimiter in their culture, e.g. ',' (comma).