### PR TITLE
Disable items in settings panels, which we don't plan to use.

### DIFF
--- a/src/nunit-gui/Views/SettingsPages/AdvancedEngineSettingsPage.Designer.cs
+++ b/src/nunit-gui/Views/SettingsPages/AdvancedEngineSettingsPage.Designer.cs
@@ -104,6 +104,7 @@
             // 
             // shadowCopyPathTextBox
             // 
+            this.shadowCopyPathTextBox.Enabled = false;
             this.shadowCopyPathTextBox.Location = new System.Drawing.Point(134, 57);
             this.shadowCopyPathTextBox.Name = "shadowCopyPathTextBox";
             this.shadowCopyPathTextBox.Size = new System.Drawing.Size(325, 20);

--- a/src/nunit-gui/Views/SettingsPages/AdvancedEngineSettingsPage.cs
+++ b/src/nunit-gui/Views/SettingsPages/AdvancedEngineSettingsPage.cs
@@ -82,7 +82,7 @@ namespace NUnit.Gui.Views.SettingsPages
 
         private void enableShadowCopyCheckBox_CheckedChanged(object sender, EventArgs e)
         {
-            shadowCopyPathTextBox.Enabled = enableShadowCopyCheckBox.Checked;
+            //shadowCopyPathTextBox.Enabled = enableShadowCopyCheckBox.Checked;
         }
 
         private void principalPolicyCheckBox_CheckedChanged(object sender, EventArgs e)

--- a/src/nunit-gui/Views/SettingsPages/AssemblyIsolationSettingsPage.Designer.cs
+++ b/src/nunit-gui/Views/SettingsPages/AssemblyIsolationSettingsPage.Designer.cs
@@ -62,6 +62,7 @@
             // 
             this.sameProcessRadioButton.AutoSize = true;
             this.sameProcessRadioButton.Checked = true;
+            this.sameProcessRadioButton.Enabled = false;
             this.sameProcessRadioButton.Location = new System.Drawing.Point(19, 25);
             this.sameProcessRadioButton.Name = "sameProcessRadioButton";
             this.sameProcessRadioButton.Size = new System.Drawing.Size(205, 17);
@@ -73,6 +74,7 @@
             // separateProcessRadioButton
             // 
             this.separateProcessRadioButton.AutoSize = true;
+            this.separateProcessRadioButton.Enabled = false;
             this.separateProcessRadioButton.Location = new System.Drawing.Point(19, 58);
             this.separateProcessRadioButton.Name = "separateProcessRadioButton";
             this.separateProcessRadioButton.Size = new System.Drawing.Size(204, 17);
@@ -83,6 +85,7 @@
             // multiProcessRadioButton
             // 
             this.multiProcessRadioButton.AutoSize = true;
+            this.multiProcessRadioButton.Enabled = false;
             this.multiProcessRadioButton.Location = new System.Drawing.Point(19, 91);
             this.multiProcessRadioButton.Name = "multiProcessRadioButton";
             this.multiProcessRadioButton.Size = new System.Drawing.Size(239, 17);
@@ -114,6 +117,7 @@
             this.singleDomainRadioButton.AutoCheck = false;
             this.singleDomainRadioButton.AutoSize = true;
             this.singleDomainRadioButton.Checked = true;
+            this.singleDomainRadioButton.Enabled = false;
             this.singleDomainRadioButton.Location = new System.Drawing.Point(19, 182);
             this.singleDomainRadioButton.Name = "singleDomainRadioButton";
             this.singleDomainRadioButton.Size = new System.Drawing.Size(194, 17);
@@ -126,6 +130,7 @@
             // 
             this.multiDomainRadioButton.AutoCheck = false;
             this.multiDomainRadioButton.AutoSize = true;
+            this.multiDomainRadioButton.Enabled = false;
             this.multiDomainRadioButton.Location = new System.Drawing.Point(19, 152);
             this.multiDomainRadioButton.Name = "multiDomainRadioButton";
             this.multiDomainRadioButton.Size = new System.Drawing.Size(220, 17);

--- a/src/nunit-gui/Views/SettingsPages/GuiSettingsPage.Designer.cs
+++ b/src/nunit-gui/Views/SettingsPages/GuiSettingsPage.Designer.cs
@@ -44,6 +44,7 @@
             // checkFilesExistCheckBox
             // 
             this.checkFilesExistCheckBox.AutoSize = true;
+            this.checkFilesExistCheckBox.Enabled = false;
             this.checkFilesExistCheckBox.Location = new System.Drawing.Point(27, 159);
             this.checkFilesExistCheckBox.Name = "checkFilesExistCheckBox";
             this.checkFilesExistCheckBox.Size = new System.Drawing.Size(185, 17);
@@ -54,6 +55,7 @@
             // miniGuiRadioButton
             // 
             this.miniGuiRadioButton.AutoSize = true;
+            this.miniGuiRadioButton.Enabled = false;
             this.miniGuiRadioButton.Location = new System.Drawing.Point(27, 56);
             this.miniGuiRadioButton.Name = "miniGuiRadioButton";
             this.miniGuiRadioButton.Size = new System.Drawing.Size(148, 17);
@@ -63,6 +65,7 @@
             // fullGuiRadioButton
             // 
             this.fullGuiRadioButton.AutoSize = true;
+            this.fullGuiRadioButton.Enabled = false;
             this.fullGuiRadioButton.Location = new System.Drawing.Point(27, 24);
             this.fullGuiRadioButton.Name = "fullGuiRadioButton";
             this.fullGuiRadioButton.Size = new System.Drawing.Size(215, 17);
@@ -99,6 +102,7 @@
             // loadLastProjectCheckBox
             // 
             this.loadLastProjectCheckBox.AutoSize = true;
+            this.loadLastProjectCheckBox.Enabled = false;
             this.loadLastProjectCheckBox.Location = new System.Drawing.Point(27, 198);
             this.loadLastProjectCheckBox.Name = "loadLastProjectCheckBox";
             this.loadLastProjectCheckBox.Size = new System.Drawing.Size(193, 17);

--- a/src/nunit-gui/Views/SettingsPages/ProjectEditorSettingsPage.Designer.cs
+++ b/src/nunit-gui/Views/SettingsPages/ProjectEditorSettingsPage.Designer.cs
@@ -40,6 +40,7 @@
             // useOtherEditorRadioButton
             // 
             this.useOtherEditorRadioButton.AutoSize = true;
+            this.useOtherEditorRadioButton.Enabled = false;
             this.useOtherEditorRadioButton.Location = new System.Drawing.Point(21, 66);
             this.useOtherEditorRadioButton.Name = "useOtherEditorRadioButton";
             this.useOtherEditorRadioButton.Size = new System.Drawing.Size(89, 17);
@@ -51,6 +52,7 @@
             // useNUnitEditorRadioButton
             // 
             this.useNUnitEditorRadioButton.AutoSize = true;
+            this.useNUnitEditorRadioButton.Enabled = false;
             this.useNUnitEditorRadioButton.Location = new System.Drawing.Point(21, 39);
             this.useNUnitEditorRadioButton.Name = "useNUnitEditorRadioButton";
             this.useNUnitEditorRadioButton.Size = new System.Drawing.Size(140, 17);
@@ -74,6 +76,7 @@
             // 
             this.editorPathTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.editorPathTextBox.Enabled = false;
             this.editorPathTextBox.Location = new System.Drawing.Point(113, 64);
             this.editorPathTextBox.Name = "editorPathTextBox";
             this.editorPathTextBox.Size = new System.Drawing.Size(281, 20);

--- a/src/nunit-gui/Views/SettingsPages/RuntimeSelectionSettingsPage.Designer.cs
+++ b/src/nunit-gui/Views/SettingsPages/RuntimeSelectionSettingsPage.Designer.cs
@@ -35,6 +35,7 @@
             // 
             // runtimeSelectionCheckBox
             // 
+            this.runtimeSelectionCheckBox.Enabled = false;
             this.runtimeSelectionCheckBox.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.runtimeSelectionCheckBox.Location = new System.Drawing.Point(29, 32);
             this.runtimeSelectionCheckBox.Name = "runtimeSelectionCheckBox";

--- a/src/nunit-gui/Views/SettingsPages/TreeSettingsPage.Designer.cs
+++ b/src/nunit-gui/Views/SettingsPages/TreeSettingsPage.Designer.cs
@@ -57,6 +57,7 @@
             // 
             // imageSetListBox
             // 
+            this.imageSetListBox.Enabled = false;
             this.imageSetListBox.FormattingEnabled = true;
             this.imageSetListBox.Location = new System.Drawing.Point(233, 67);
             this.imageSetListBox.Name = "imageSetListBox";
@@ -144,6 +145,7 @@
             // 
             this.flatTestList.AutoCheck = false;
             this.flatTestList.AutoSize = true;
+            this.flatTestList.Enabled = false;
             this.flatTestList.Location = new System.Drawing.Point(29, 275);
             this.flatTestList.Name = "flatTestList";
             this.flatTestList.Size = new System.Drawing.Size(129, 17);
@@ -155,6 +157,7 @@
             this.autoNamespaceSuites.AutoCheck = false;
             this.autoNamespaceSuites.AutoSize = true;
             this.autoNamespaceSuites.Checked = true;
+            this.autoNamespaceSuites.Enabled = false;
             this.autoNamespaceSuites.Location = new System.Drawing.Point(29, 249);
             this.autoNamespaceSuites.Name = "autoNamespaceSuites";
             this.autoNamespaceSuites.Size = new System.Drawing.Size(162, 17);
@@ -175,6 +178,7 @@
             // showCheckBoxesCheckBox
             // 
             this.showCheckBoxesCheckBox.AutoSize = true;
+            this.showCheckBoxesCheckBox.Enabled = false;
             this.showCheckBoxesCheckBox.Location = new System.Drawing.Point(29, 187);
             this.showCheckBoxesCheckBox.Name = "showCheckBoxesCheckBox";
             this.showCheckBoxesCheckBox.Size = new System.Drawing.Size(116, 17);
@@ -207,6 +211,7 @@
             // clearResultsCheckBox
             // 
             this.clearResultsCheckBox.AutoSize = true;
+            this.clearResultsCheckBox.Enabled = false;
             this.clearResultsCheckBox.Location = new System.Drawing.Point(29, 135);
             this.clearResultsCheckBox.Name = "clearResultsCheckBox";
             this.clearResultsCheckBox.Size = new System.Drawing.Size(161, 17);
@@ -218,9 +223,9 @@
             this.saveVisualStateCheckBox.AutoSize = true;
             this.saveVisualStateCheckBox.Location = new System.Drawing.Point(29, 161);
             this.saveVisualStateCheckBox.Name = "saveVisualStateCheckBox";
-            this.saveVisualStateCheckBox.Size = new System.Drawing.Size(184, 17);
+            this.saveVisualStateCheckBox.Size = new System.Drawing.Size(234, 17);
             this.saveVisualStateCheckBox.TabIndex = 60;
-            this.saveVisualStateCheckBox.Text = "Save Visual State of each project";
+            this.saveVisualStateCheckBox.Text = "Restore Visual State of each project on load";
             // 
             // groupBox1
             // 


### PR DESCRIPTION
This is a preliminary step toward resolving issue #86. The settings we do not currently support are disabled in the panels to make their status more visible.