### PR TITLE
Eliminate console window display when running in separate process

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="NUnit Gui Team Feed" value="https://www.myget.org/F/nunit-gui-team/api/v3/index.json" />
+    <add key="NUnit Gui Team Feed" value="https://www.myget.org/F/nunit-gui-team/api/v2" />
   </packageSources>
 </configuration>

--- a/build.cake
+++ b/build.cake
@@ -33,6 +33,13 @@ var GUI_SOLUTION = PROJECT_DIR + "nunit-gui.sln";
 // Test Assembly
 var GUI_TESTS = BIN_DIR + "nunit-gui.tests.dll";
 
+// Package sources for nuget restore
+var PACKAGE_SOURCE = new string[]
+{
+	"https://www.myget.org/F/nunit-gui-team/api/v3/index.json",
+	"https://www.myget.org/F/nunit-gui-team/api/v2"
+};
+
 // Packages
 var SRC_PACKAGE = PACKAGE_DIR + "NUnit-Gui-" + version + modifier + "-src.zip";
 var ZIP_PACKAGE = PACKAGE_DIR + "NUnit-Gui-" + packageVersion + ".zip";
@@ -55,7 +62,11 @@ Task("Clean")
 Task("InitializeBuild")
     .Does(() =>
 {
-    NuGetRestore(GUI_SOLUTION);
+    NuGetRestore(GUI_SOLUTION, new NuGetRestoreSettings
+	{
+		Source = PACKAGE_SOURCE,
+		Verbosity = NuGetVerbosity.Detailed
+	});
 
 	if (BuildSystem.IsRunningOnAppVeyor)
 	{

--- a/src/nunit-gui/Model/TestModel.cs
+++ b/src/nunit-gui/Model/TestModel.cs
@@ -269,7 +269,7 @@ namespace NUnit.Gui.Model
             var package = new TestPackage(testFiles);
 
             // TODO: Remove temporary Settings used in testing GUI
-            package.Settings["ProcessModel"] = "InProcess";
+            //package.Settings["ProcessModel"] = "InProcess";
             package.Settings["NumberOfTestWorkers"] = 0;
 
             //if (options.ProcessModel != null)
@@ -302,8 +302,7 @@ namespace NUnit.Gui.Model
 
         private void RunTests(TestFilter filter)
         {
-            Thread thread = new Thread(() => Runner.Run(this, filter));
-            thread.Start();
+            Runner.RunAsync(this, filter);
         }
 
         public void CancelTestRun()

--- a/src/nunit-gui/nunit-gui.csproj
+++ b/src/nunit-gui/nunit-gui.csproj
@@ -34,15 +34,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-dev-03383\lib\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\nunit.engine.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-dev-03383\lib\nunit.engine.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-dev-03383\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/nunit-gui/nunit-gui.csproj
+++ b/src/nunit-gui/nunit-gui.csproj
@@ -34,15 +34,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.5.0\lib\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.engine, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.5.0\lib\nunit.engine.dll</HintPath>
+    <Reference Include="nunit.engine, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\nunit.engine.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.5.0\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/nunit-gui/packages.config
+++ b/src/nunit-gui/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine" version="3.5.0" targetFramework="net20" />
+  <package id="NUnit.Engine" version="3.6.0-ci-03382-pr-146" targetFramework="net20" />
 </packages>

--- a/src/nunit-gui/packages.config
+++ b/src/nunit-gui/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine" version="3.6.0-ci-03382-pr-146" targetFramework="net20" />
+  <package id="NUnit.Engine" version="3.6.0-dev-03383" targetFramework="net20" />
 </packages>

--- a/src/tests/nunit-gui.tests.csproj
+++ b/src/tests/nunit-gui.tests.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-dev-03383\lib\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
@@ -40,11 +40,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\nunit.engine.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-dev-03383\lib\nunit.engine.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-dev-03383\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/tests/nunit-gui.tests.csproj
+++ b/src/tests/nunit-gui.tests.csproj
@@ -32,19 +32,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.5.0\lib\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NSubstitute.1.10.0.0\lib\net35\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.engine, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.5.0\lib\nunit.engine.dll</HintPath>
+    <Reference Include="nunit.engine, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\nunit.engine.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.5.0\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.6.0-ci-03382-pr-146\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/tests/packages.config
+++ b/src/tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net35" />
   <package id="NUnit" version="3.5.0" targetFramework="net35" />
-  <package id="NUnit.Engine" version="3.6.0-ci-03382-pr-146" targetFramework="net35" />
+  <package id="NUnit.Engine" version="3.6.0-dev-03383" targetFramework="net35" />
 </packages>

--- a/src/tests/packages.config
+++ b/src/tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net35" />
   <package id="NUnit" version="3.5.0" targetFramework="net35" />
-  <package id="NUnit.Engine" version="3.5.0" targetFramework="net35" />
+  <package id="NUnit.Engine" version="3.6.0-ci-03382-pr-146" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
This fix makes use of a pre-release build of NUnit Engine 3.6 to avoid creating a window when launching the agent process. It also fixes a problem that prevented use of RunAsync in the gui when running tests.
