### PR TITLE
SettingsLoaded only true after LoadSettings call

### DIFF
--- a/src/nunit-gui/Views/SettingsPage.cs
+++ b/src/nunit-gui/Views/SettingsPage.cs
@@ -22,11 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Text;
 using System.Windows.Forms;
 
 namespace NUnit.Gui.Views
@@ -56,16 +51,15 @@ namespace NUnit.Gui.Views
 
         #region Properties
 
+        private bool settingsLoaded;
+
         protected SettingsModel Settings { get; private set; }
 
         protected IMessageDisplay MessageDisplay { get; private set; }
 
         public string Key { get; private set; }
 
-        public bool SettingsLoaded
-        {
-            get { return true; }// _settings != null; }
-        }
+        public bool SettingsLoaded => settingsLoaded;
 
         public virtual bool HasChangesRequiringReload
         {
@@ -86,13 +80,19 @@ namespace NUnit.Gui.Views
 
         #endregion
 
+        void LoadAndSetSettings()
+        {
+            settingsLoaded = true;
+            LoadSettings();
+        }
+
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
 
             if (!DesignMode)
             {
-                this.LoadSettings();
+                this.LoadAndSetSettings();
             }
         }
     }

--- a/src/nunit-gui/Views/SettingsPage.cs
+++ b/src/nunit-gui/Views/SettingsPage.cs
@@ -51,15 +51,13 @@ namespace NUnit.Gui.Views
 
         #region Properties
 
-        private bool settingsLoaded;
-
         protected SettingsModel Settings { get; private set; }
 
         protected IMessageDisplay MessageDisplay { get; private set; }
 
         public string Key { get; private set; }
 
-        public bool SettingsLoaded => settingsLoaded;
+        public bool SettingsLoaded { get; private set; }
 
         public virtual bool HasChangesRequiringReload
         {
@@ -80,19 +78,14 @@ namespace NUnit.Gui.Views
 
         #endregion
 
-        void LoadAndSetSettings()
-        {
-            settingsLoaded = true;
-            LoadSettings();
-        }
-
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
 
             if (!DesignMode)
             {
-                this.LoadAndSetSettings();
+                this.LoadSettings();
+                SettingsLoaded = true;
             }
         }
     }


### PR DESCRIPTION
Otherwise, we could end up in a situation where ApplySettings
is called even if LoadSettings is not called.

Fixes #130