### PR TITLE
Parsing and validation of options

### DIFF
--- a/src/nunit-gui/CommandLineOptions.cs
+++ b/src/nunit-gui/CommandLineOptions.cs
@@ -129,7 +129,7 @@ namespace NUnit.Gui
 
         // Error Processing
 
-        public List<string> errorMessages = new List<string>();
+        private List<string> errorMessages = new List<string>();
         public IList<string> ErrorMessages { get { return errorMessages; } }
 
         #endregion
@@ -154,7 +154,7 @@ namespace NUnit.Gui
 
         private string RequiredValue(string val, string option, params string[] validValues)
         {
-            if (val == null || val == string.Empty)
+            if (string.IsNullOrEmpty(val))
                 ErrorMessages.Add("Missing required value for option '" + option + "'.");
 
             bool isValid = true;
@@ -164,8 +164,8 @@ namespace NUnit.Gui
                 isValid = false;
 
                 foreach (string valid in validValues)
-                    if (string.Compare(valid, val, true) == 0)
-                        isValid = true;
+                    if (string.Compare(valid, val, StringComparison.OrdinalIgnoreCase) == 0)
+                        return valid;
 
             }
 

--- a/src/nunit-gui/Program.cs
+++ b/src/nunit-gui/Program.cs
@@ -56,6 +56,19 @@ namespace NUnit.Gui
                 return;
             }
 
+            if (!options.Validate())
+            {
+                var errMessage = new string[options.ErrorMessages.Count];
+                options.ErrorMessages.CopyTo(errMessage, 0);
+                var msg =
+                    "There were the following errors parsing the options:" + Environment.NewLine +
+                    string.Join(Environment.NewLine, errMessage) + Environment.NewLine +
+                    Environment.NewLine +
+                    "Use the option '--help' to show the possible options and their values.";
+                MessageBox.Show(msg, "NUnit - Problem parsing options", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
             if (options.ShowHelp)
             {
                 ShowHelpText(options);


### PR DESCRIPTION
The method RequiredValue is changed to match the same
method in nunit-console project, hence we now support
values that differ in casing (and RequiredValue corrects
the casing).

Furthermore, the options are now validated, and a
messagebox is presented to the user if the options
are invalid.

Fixes #163