### PR TITLE
Update Message and StackTrace

### DIFF
--- a/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
@@ -124,11 +124,8 @@ namespace NUnit.Gui.Presenters
                         message = resultNode.Xml.SelectSingleNode("reason/message");
                     }
 
-                    if (message != null)
-                        _view.Message = message.InnerText;
-
-                    if (stackTrace != null)
-                        _view.StackTrace = stackTrace.InnerText;
+                    _view.Message = message?.InnerText ?? "";
+                    _view.StackTrace = stackTrace?.InnerText ?? "";
 
                     var output = resultNode.Xml.SelectSingleNode("output");
                     _view.Output = output != null ? output.InnerText : "";


### PR DESCRIPTION
Message and StackTrace are now reset to "" if the
test does not contain a "message"/"stack-trace"
XML node, repectively.

Fixes #173