### PR TITLE
Lift Cake version to 0.19.1

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.15.2" />
+    <package id="Cake" version="0.19.1" />
     <package id="NUnit.ConsoleRunner" version="3.6.1" />
 </packages>


### PR DESCRIPTION
Make nunit-gui use the same version of Cake as nunit-console to
make it possible to compile the project on a computer with
only VS 2017 installed.

Fixes #179