### PR TITLE
Allow changing ProcessModel and DomainUsage

### DIFF
--- a/src/nunit-gui/Model/ITestModel.cs
+++ b/src/nunit-gui/Model/ITestModel.cs
@@ -63,6 +63,8 @@ namespace NUnit.Gui.Model
 
         CommandLineOptions Options { get; }
 
+        IDictionary<string, object> PackageSettings { get; }
+
         IRecentFiles RecentFiles { get; }
 
         bool IsPackageLoaded { get; }
@@ -105,9 +107,6 @@ namespace NUnit.Gui.Model
 
         // Reload current TestPackage
         void ReloadTests();
-
-        // Reload current TestPackage using specified runtime
-        void ReloadTests(string runtime);
 
         // Run all the tests
         void RunAllTests();

--- a/src/nunit-gui/Model/TestModel.cs
+++ b/src/nunit-gui/Model/TestModel.cs
@@ -76,6 +76,8 @@ namespace NUnit.Gui.Model
 
         public CommandLineOptions Options { get; private set; }
 
+        public IDictionary<string, object> PackageSettings { get; } = new Dictionary<string, object>();
+
         public IRecentFiles RecentFiles { get; private set; }
 
         public ITestRunner Runner { get; private set; }
@@ -244,31 +246,25 @@ namespace NUnit.Gui.Model
 
         public void ReloadTests()
         {
-            ReloadTests(null);
-        }
-
-        public void ReloadTests(string runtime)
-        {
             Runner.Unload();
             _resultIndex.Clear();
             Tests = null;
 
             _package = MakeTestPackage(_files);
-            if (runtime != null)
-                _package.Settings["RuntimeFramework"] = runtime;
+
             Runner = _testEngine.GetRunner(_package);
 
             Tests = new TestNode(Runner.Explore(TestFilter.Empty));
 
             _resultIndex.Clear();
 
-            if (TestReloaded != null)
-                TestReloaded(new TestNodeEventArgs(TestAction.TestReloaded, Tests));
+            TestReloaded(new TestNodeEventArgs(TestAction.TestReloaded, Tests));
         }
 
         #region Helper Methods
 
-        private TestPackage MakeTestPackage(IList<string> testFiles)
+        // Public for testing only
+        public TestPackage MakeTestPackage(IList<string> testFiles)
         {
             var package = new TestPackage(testFiles);
 
@@ -287,6 +283,9 @@ namespace NUnit.Gui.Model
 
             if (Options.InternalTraceLevel != null)
                 package.Settings["InternalTraceLevel"] = Options.InternalTraceLevel;
+
+            foreach (var entry in PackageSettings)
+                package.Settings[entry.Key] = entry.Value;               
 
             return package;
         }

--- a/src/nunit-gui/Model/TestModel.cs
+++ b/src/nunit-gui/Model/TestModel.cs
@@ -285,7 +285,7 @@ namespace NUnit.Gui.Model
                 package.Settings["InternalTraceLevel"] = Options.InternalTraceLevel;
 
             foreach (var entry in PackageSettings)
-                package.Settings[entry.Key] = entry.Value;               
+                package.Settings[entry.Key] = entry.Value;
 
             return package;
         }

--- a/src/nunit-gui/Presenters/MainPresenter.cs
+++ b/src/nunit-gui/Presenters/MainPresenter.cs
@@ -74,6 +74,7 @@ namespace NUnit.Gui.Presenters
             _view.SelectedRuntime.SelectionChanged += SelectedRuntime_SelectionChanged;
             _view.ProcessModel.SelectionChanged += ProcessModel_SelectionChanged;
             _view.DomainUsage.SelectionChanged += DomainUsage_SelectionChanged;
+            _view.RunAsX86.CheckedChanged += LoadAsX86_CheckedChanged;
             _view.ExitCommand.Execute += () => Application.Exit();
 
             _view.SettingsCommand.Execute += OpenSettingsDialogCommand_Execute;
@@ -209,9 +210,18 @@ namespace NUnit.Gui.Presenters
             ChangePackageSetting(EnginePackageSettings.DomainUsage, _view.DomainUsage.SelectedItem);
         }
 
-        private void ChangePackageSetting(string key, string setting)
+        private void LoadAsX86_CheckedChanged()
         {
-            if (setting == "DEFAULT")
+            var key = EnginePackageSettings.RunAsX86;
+            if (_view.RunAsX86.Checked)
+                ChangePackageSetting(key, true);
+            else
+                ChangePackageSetting(key, null);
+        }
+
+        private void ChangePackageSetting(string key, object setting)
+        {
+            if (setting == null || setting is string && (string)setting == "DEFAULT")
                 _model.PackageSettings.Remove(key);
             else
                 _model.PackageSettings[key] = setting;

--- a/src/nunit-gui/Presenters/MainPresenter.cs
+++ b/src/nunit-gui/Presenters/MainPresenter.cs
@@ -69,7 +69,7 @@ namespace NUnit.Gui.Presenters
             _view.CloseCommand.Execute += _model.UnloadTests;
             _view.SaveCommand.Execute += _model.SaveProject;
             _view.SaveAsCommand.Execute += _model.SaveProject;
-            _view.ReloadTestsCommand.Execute += () => _model.ReloadTests();
+            _view.ReloadTestsCommand.Execute += _model.ReloadTests;
             _view.RecentProjectsMenu.Popup += RecentProjectsMenu_Popup;
             _view.SelectedRuntime.SelectionChanged += SelectedRuntime_SelectionChanged;
             _view.ProcessModel.SelectionChanged += ProcessModel_SelectionChanged;
@@ -128,9 +128,7 @@ namespace NUnit.Gui.Presenters
                     // Don't use Full suffix, but keep Client if present
                     if (text.EndsWith(" - Full"))
                         text = text.Substring(0, text.Length - 7);
-                    var menuItem = new ToolStripMenuItem(text);
-                    menuItem.Tag = runtime.ToString();
-                    dropDownItems.Add(menuItem);
+                    dropDownItems.Add(new ToolStripMenuItem(text) { Tag = runtime.ToString() });
                 }
 
                 _view.SelectedRuntime.Refresh();
@@ -138,9 +136,6 @@ namespace NUnit.Gui.Presenters
 
             // Project Menu
             _view.ProjectMenu.Enabled = _view.ProjectMenu.Visible = _model.HasTests;
-            //_view.SelectRuntimeMenu.Enabled = canCloseOrSave;
-            //_view.ProcessModel.Enabled = canCloseOrSave;
-            //_view.DomainUsage.Enabled = canCloseOrSave;
         }
 
         #endregion
@@ -221,7 +216,7 @@ namespace NUnit.Gui.Presenters
 
         private void ChangePackageSetting(string key, object setting)
         {
-            if (setting == null || setting is string && (string)setting == "DEFAULT")
+            if (setting == null || setting as string == "DEFAULT")
                 _model.PackageSettings.Remove(key);
             else
                 _model.PackageSettings[key] = setting;
@@ -270,21 +265,21 @@ namespace NUnit.Gui.Presenters
             // HACK: This expsoses the underlying ToolStripMenuItem
             var dropDownItems = _view.RecentProjectsMenu.DropDownItems;
             // Test for null, in case we are running tests with a mock
-            if (dropDownItems != null)
+            if (dropDownItems == null)
+                return;
+
+            dropDownItems.Clear();
+            int num = 0;
+            foreach (string entry in _model.RecentFiles.Entries)
             {
-                dropDownItems.Clear();
-                int num = 0;
-                foreach (string entry in _model.RecentFiles.Entries)
+                var menuText = string.Format("{0} {1}", ++num, entry);
+                var menuItem = new ToolStripMenuItem(menuText);
+                menuItem.Click += (sender, ea) =>
                 {
-                    var menuText = string.Format("{0} {1}", ++num, entry);
-                    var menuItem = new ToolStripMenuItem(menuText);
-                    menuItem.Click += (sender, ea) =>
-                    {
-                        string path = ((ToolStripMenuItem)sender).Text.Substring(2);
-                        _model.LoadTests(new[] { path });
-                    };
-                    dropDownItems.Add(menuItem);
-                }
+                    string path = ((ToolStripMenuItem)sender).Text.Substring(2);
+                    _model.LoadTests(new[] { path });
+                };
+                dropDownItems.Add(menuItem);
             }
         }
 

--- a/src/nunit-gui/Presenters/XmlPresenter.cs
+++ b/src/nunit-gui/Presenters/XmlPresenter.cs
@@ -66,11 +66,11 @@ namespace NUnit.Gui.Presenters
             };
             _view.SelectionChanged += () =>
             {
-                _view.CopyToolStripMenuItem.ToolStripItem.Enabled = !string.IsNullOrEmpty(_view.XmlTextBox.Control.SelectedText);
+                _view.CopyToolStripMenuItem.Enabled = !string.IsNullOrEmpty(_view.XmlTextBox.Control.SelectedText);
             };
             _view.WordWrapChanged += () =>
             {
-                _view.XmlTextBox.Control.WordWrap = _view.WordWrapToolStripMenuItem.ToolStripItem.Checked;
+                _view.XmlTextBox.Control.WordWrap = _view.WordWrapToolStripMenuItem.Checked;
             };
             _view.CopyCommand += () =>
             {

--- a/src/nunit-gui/Views/IMainView.cs
+++ b/src/nunit-gui/Views/IMainView.cs
@@ -51,6 +51,7 @@ namespace NUnit.Gui.Views
         IMenu SelectRuntimeMenu { get; }
         ISelection SelectedRuntime { get; }
         ISelection ProcessModel { get; }
+        IChecked RunAsX86 { get; }
         ISelection DomainUsage { get; }
         IMenu RecentProjectsMenu { get; }
         ICommand ExitCommand { get; }

--- a/src/nunit-gui/Views/IMainView.cs
+++ b/src/nunit-gui/Views/IMainView.cs
@@ -23,6 +23,7 @@
 
 using System.Drawing;
 using System.Windows.Forms;
+using NUnit.UiKit;
 using NUnit.UiKit.Elements;
 
 namespace NUnit.Gui.Views
@@ -39,7 +40,7 @@ namespace NUnit.Gui.Views
         event DragEventHandler DragDrop;
 
         // File Menu
-        IPopup FileMenu { get; }
+        IMenu FileMenu { get; }
         ICommand NewProjectCommand { get; }
         ICommand OpenProjectCommand { get; }
         ICommand CloseCommand { get; }
@@ -47,8 +48,11 @@ namespace NUnit.Gui.Views
         ICommand SaveAsCommand { get; }
         ICommand SaveResultsCommand { get; }
         ICommand ReloadTestsCommand { get; }
-        IPopup SelectRuntimeMenu { get; }
-        IPopup RecentProjectsMenu { get; }
+        IMenu SelectRuntimeMenu { get; }
+        ISelection SelectedRuntime { get; }
+        ISelection ProcessModel { get; }
+        ISelection DomainUsage { get; }
+        IMenu RecentProjectsMenu { get; }
         ICommand ExitCommand { get; }
 
         // View Menu
@@ -59,7 +63,7 @@ namespace NUnit.Gui.Views
         // Status Bar
 
         // Project Menu
-        IPopup ProjectMenu { get; }
+        IMenu ProjectMenu { get; }
         // Configurations
         // Insert Assembly
         // Insert Project
@@ -87,5 +91,8 @@ namespace NUnit.Gui.Views
 
         // Dialogs
         IDialogManager DialogManager { get; }
+
+        // Messages
+        IMessageDisplay MessageDisplay { get; }
     }
 }

--- a/src/nunit-gui/Views/MainForm.Designer.cs
+++ b/src/nunit-gui/Views/MainForm.Designer.cs
@@ -265,7 +265,7 @@ namespace NUnit.Gui.Views
             // defaultRuntimeToolStripMenuItem
             // 
             this.defaultRuntimeToolStripMenuItem.Name = "defaultRuntimeToolStripMenuItem";
-            this.defaultRuntimeToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.defaultRuntimeToolStripMenuItem.Size = new System.Drawing.Size(112, 22);
             this.defaultRuntimeToolStripMenuItem.Tag = "DEFAULT";
             this.defaultRuntimeToolStripMenuItem.Text = "Default";
             // 
@@ -285,41 +285,48 @@ namespace NUnit.Gui.Views
             // defaultProcessToolStripMenuItem
             // 
             this.defaultProcessToolStripMenuItem.Name = "defaultProcessToolStripMenuItem";
-            this.defaultProcessToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.defaultProcessToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.defaultProcessToolStripMenuItem.Tag = "DEFAULT";
             this.defaultProcessToolStripMenuItem.Text = "Default";
+            this.defaultProcessToolStripMenuItem.ToolTipText = "Each assembly is loaded in it\'s own process.";
             // 
             // inProcessToolStripMenuItem
             // 
             this.inProcessToolStripMenuItem.Name = "inProcessToolStripMenuItem";
-            this.inProcessToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.inProcessToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.inProcessToolStripMenuItem.Tag = "InProcess";
             this.inProcessToolStripMenuItem.Text = "InProcess";
+            this.inProcessToolStripMenuItem.ToolTipText = "Test assemblies are loaded directly in the NUnit process.";
             // 
             // singleProcessToolStripMenuItem
             // 
             this.singleProcessToolStripMenuItem.Name = "singleProcessToolStripMenuItem";
-            this.singleProcessToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.singleProcessToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.singleProcessToolStripMenuItem.Tag = "Single";
             this.singleProcessToolStripMenuItem.Text = "Single";
+            this.singleProcessToolStripMenuItem.ToolTipText = "All test assemblies are loaded in the same process, separate from the NUnit proce" +
+    "ss.";
             // 
             // multipleProcessToolStripMenuItem
             // 
             this.multipleProcessToolStripMenuItem.Name = "multipleProcessToolStripMenuItem";
-            this.multipleProcessToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.multipleProcessToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.multipleProcessToolStripMenuItem.Tag = "Multiple";
             this.multipleProcessToolStripMenuItem.Text = "Multiple";
+            this.multipleProcessToolStripMenuItem.ToolTipText = "Each assembly is loaded in it\'s own process.";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(133, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(149, 6);
             // 
             // loadAsX86ToolStripMenuItem
             // 
+            this.loadAsX86ToolStripMenuItem.CheckOnClick = true;
             this.loadAsX86ToolStripMenuItem.Name = "loadAsX86ToolStripMenuItem";
-            this.loadAsX86ToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
-            this.loadAsX86ToolStripMenuItem.Text = "Load as X86";
+            this.loadAsX86ToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.loadAsX86ToolStripMenuItem.Text = "Run as X86";
+            this.loadAsX86ToolStripMenuItem.ToolTipText = "If checked, forces loading of the test assembly in 32-bit mode.";
             // 
             // domainUsageToolStripMenuItem1
             // 
@@ -725,7 +732,7 @@ namespace NUnit.Gui.Views
             this.tabPage2.Margin = new System.Windows.Forms.Padding(2);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(2);
-            this.tabPage2.Size = new System.Drawing.Size(341, 342);
+            this.tabPage2.Size = new System.Drawing.Size(341, 336);
             this.tabPage2.TabIndex = 4;
             this.tabPage2.Text = "XML";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -786,7 +793,7 @@ namespace NUnit.Gui.Views
             this.xmlView.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.xmlView.Name = "xmlView";
             this.xmlView.Padding = new System.Windows.Forms.Padding(0, 3, 0, 0);
-            this.xmlView.Size = new System.Drawing.Size(337, 338);
+            this.xmlView.Size = new System.Drawing.Size(337, 332);
             this.xmlView.TabIndex = 2;
             this.xmlView.TestXml = null;
             // 

--- a/src/nunit-gui/Views/MainForm.Designer.cs
+++ b/src/nunit-gui/Views/MainForm.Designer.cs
@@ -34,10 +34,8 @@ namespace NUnit.Gui.Views
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.tabPage1 = new System.Windows.Forms.TabPage();
-            this.propertiesView = new NUnit.Gui.Views.TestPropertiesView();
             this.testName = new System.Windows.Forms.Label();
             this.testResult = new System.Windows.Forms.Label();
-            this.statusBarView = new NUnit.Gui.Views.StatusBarView();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.newProjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openProjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -48,8 +46,20 @@ namespace NUnit.Gui.Views
             this.saveResultsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.reloadTestsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.selectRuntimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dummyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.defaultRuntimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.processModelToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.defaultProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.inProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.singleProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.multipleProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.loadAsX86ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.domainUsageToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.defaultDomainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.singleDomainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.multipleDomainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
             this.recentProjectsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripSeparator();
@@ -95,11 +105,13 @@ namespace NUnit.Gui.Views
             this.aboutNUnitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.testTreeView = new NUnit.Gui.Views.TestTreeView();
-            this.progressBarView = new NUnit.Gui.Views.ProgressBarView();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage2 = new System.Windows.Forms.TabPage();
+            this.testTreeView = new NUnit.Gui.Views.TestTreeView();
+            this.progressBarView = new NUnit.Gui.Views.ProgressBarView();
+            this.propertiesView = new NUnit.Gui.Views.TestPropertiesView();
             this.xmlView = new NUnit.Gui.Views.XmlView();
+            this.statusBarView = new NUnit.Gui.Views.StatusBarView();
             this.tabPage1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -121,9 +133,10 @@ namespace NUnit.Gui.Views
             this.tabPage1.Controls.Add(this.testName);
             this.tabPage1.Controls.Add(this.testResult);
             this.tabPage1.Location = new System.Drawing.Point(4, 4);
+            this.tabPage1.Margin = new System.Windows.Forms.Padding(2);
             this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(312, 176);
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(2);
+            this.tabPage1.Size = new System.Drawing.Size(341, 336);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Properties";
             this.toolTip1.SetToolTip(this.tabPage1, "This tab displays the properties of the test, which NUnit V2 displayed in the Pro" +
@@ -131,57 +144,22 @@ namespace NUnit.Gui.Views
             this.tabPage1.ToolTipText = "Some text";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
-            // propertiesView
-            // 
-            this.propertiesView.AssertCount = "";
-            this.propertiesView.AutoScroll = true;
-            this.propertiesView.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.propertiesView.Categories = "";
-            this.propertiesView.Description = "";
-            this.propertiesView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.propertiesView.ElapsedTime = "";
-            this.propertiesView.FullName = "";
-            this.propertiesView.Header = "";
-            this.propertiesView.Location = new System.Drawing.Point(3, 3);
-            this.propertiesView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.propertiesView.Message = "";
-            this.propertiesView.Name = "propertiesView";
-            this.propertiesView.Outcome = "";
-            this.propertiesView.Output = "";
-            this.propertiesView.Padding = new System.Windows.Forms.Padding(0, 4, 0, 0);
-            this.propertiesView.Properties = "";
-            this.propertiesView.RunState = "";
-            this.propertiesView.Size = new System.Drawing.Size(306, 170);
-            this.propertiesView.SkipReason = "";
-            this.propertiesView.StackTrace = "";
-            this.propertiesView.TabIndex = 2;
-            this.propertiesView.TestCount = "";
-            this.propertiesView.TestType = "";
-            // 
             // testName
             // 
-            this.testName.Location = new System.Drawing.Point(113, 2);
+            this.testName.Location = new System.Drawing.Point(75, 1);
+            this.testName.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.testName.Name = "testName";
-            this.testName.Size = new System.Drawing.Size(226, 13);
+            this.testName.Size = new System.Drawing.Size(151, 8);
             this.testName.TabIndex = 1;
             // 
             // testResult
             // 
             this.testResult.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.testResult.Location = new System.Drawing.Point(6, 3);
+            this.testResult.Location = new System.Drawing.Point(4, 2);
+            this.testResult.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.testResult.Name = "testResult";
-            this.testResult.Size = new System.Drawing.Size(97, 13);
+            this.testResult.Size = new System.Drawing.Size(65, 8);
             this.testResult.TabIndex = 0;
-            // 
-            // statusBarView
-            // 
-            this.statusBarView.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.statusBarView.Location = new System.Drawing.Point(0, 238);
-            this.statusBarView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.statusBarView.Name = "statusBarView";
-            this.statusBarView.Size = new System.Drawing.Size(488, 24);
-            this.statusBarView.TabIndex = 2;
-            this.toolTip1.SetToolTip(this.statusBarView, "Name of the currently executing or selected test plus stats about it.");
             // 
             // fileToolStripMenuItem
             // 
@@ -195,13 +173,16 @@ namespace NUnit.Gui.Views
             this.saveResultsToolStripMenuItem,
             this.toolStripMenuItem2,
             this.reloadTestsToolStripMenuItem,
+            this.toolStripSeparator1,
             this.selectRuntimeToolStripMenuItem,
+            this.processModelToolStripMenuItem1,
+            this.domainUsageToolStripMenuItem1,
             this.toolStripMenuItem3,
             this.recentProjectsToolStripMenuItem,
             this.toolStripMenuItem4,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 22);
             this.fileToolStripMenuItem.Text = "&File";
             // 
             // newProjectToolStripMenuItem
@@ -268,20 +249,108 @@ namespace NUnit.Gui.Views
             this.reloadTestsToolStripMenuItem.ToolTipText = "Refreshes the (possibly changed) tests, keeping as much information as possible i" +
     "n the tree.";
             // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(187, 6);
+            // 
             // selectRuntimeToolStripMenuItem
             // 
             this.selectRuntimeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.dummyToolStripMenuItem});
+            this.defaultRuntimeToolStripMenuItem});
             this.selectRuntimeToolStripMenuItem.Name = "selectRuntimeToolStripMenuItem";
             this.selectRuntimeToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
-            this.selectRuntimeToolStripMenuItem.Text = "  Select Runtime";
-            this.selectRuntimeToolStripMenuItem.ToolTipText = "Allows selecting a different runtime when refreshing the tests will be reloaded.";
+            this.selectRuntimeToolStripMenuItem.Text = "Select Runtime";
             // 
-            // dummyToolStripMenuItem
+            // defaultRuntimeToolStripMenuItem
             // 
-            this.dummyToolStripMenuItem.Name = "dummyToolStripMenuItem";
-            this.dummyToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
-            this.dummyToolStripMenuItem.Text = "dummy";
+            this.defaultRuntimeToolStripMenuItem.Name = "defaultRuntimeToolStripMenuItem";
+            this.defaultRuntimeToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.defaultRuntimeToolStripMenuItem.Tag = "DEFAULT";
+            this.defaultRuntimeToolStripMenuItem.Text = "Default";
+            // 
+            // processModelToolStripMenuItem1
+            // 
+            this.processModelToolStripMenuItem1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.defaultProcessToolStripMenuItem,
+            this.inProcessToolStripMenuItem,
+            this.singleProcessToolStripMenuItem,
+            this.multipleProcessToolStripMenuItem,
+            this.toolStripSeparator2,
+            this.loadAsX86ToolStripMenuItem});
+            this.processModelToolStripMenuItem1.Name = "processModelToolStripMenuItem1";
+            this.processModelToolStripMenuItem1.Size = new System.Drawing.Size(190, 22);
+            this.processModelToolStripMenuItem1.Text = "Process Model";
+            // 
+            // defaultProcessToolStripMenuItem
+            // 
+            this.defaultProcessToolStripMenuItem.Name = "defaultProcessToolStripMenuItem";
+            this.defaultProcessToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.defaultProcessToolStripMenuItem.Tag = "DEFAULT";
+            this.defaultProcessToolStripMenuItem.Text = "Default";
+            // 
+            // inProcessToolStripMenuItem
+            // 
+            this.inProcessToolStripMenuItem.Name = "inProcessToolStripMenuItem";
+            this.inProcessToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.inProcessToolStripMenuItem.Tag = "InProcess";
+            this.inProcessToolStripMenuItem.Text = "InProcess";
+            // 
+            // singleProcessToolStripMenuItem
+            // 
+            this.singleProcessToolStripMenuItem.Name = "singleProcessToolStripMenuItem";
+            this.singleProcessToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.singleProcessToolStripMenuItem.Tag = "Single";
+            this.singleProcessToolStripMenuItem.Text = "Single";
+            // 
+            // multipleProcessToolStripMenuItem
+            // 
+            this.multipleProcessToolStripMenuItem.Name = "multipleProcessToolStripMenuItem";
+            this.multipleProcessToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.multipleProcessToolStripMenuItem.Tag = "Multiple";
+            this.multipleProcessToolStripMenuItem.Text = "Multiple";
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(133, 6);
+            // 
+            // loadAsX86ToolStripMenuItem
+            // 
+            this.loadAsX86ToolStripMenuItem.Name = "loadAsX86ToolStripMenuItem";
+            this.loadAsX86ToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.loadAsX86ToolStripMenuItem.Text = "Load as X86";
+            // 
+            // domainUsageToolStripMenuItem1
+            // 
+            this.domainUsageToolStripMenuItem1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.defaultDomainToolStripMenuItem,
+            this.singleDomainToolStripMenuItem,
+            this.multipleDomainToolStripMenuItem});
+            this.domainUsageToolStripMenuItem1.Name = "domainUsageToolStripMenuItem1";
+            this.domainUsageToolStripMenuItem1.Size = new System.Drawing.Size(190, 22);
+            this.domainUsageToolStripMenuItem1.Text = "Domain Usage";
+            // 
+            // defaultDomainToolStripMenuItem
+            // 
+            this.defaultDomainToolStripMenuItem.Name = "defaultDomainToolStripMenuItem";
+            this.defaultDomainToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.defaultDomainToolStripMenuItem.Tag = "DEFAULT";
+            this.defaultDomainToolStripMenuItem.Text = "Default";
+            // 
+            // singleDomainToolStripMenuItem
+            // 
+            this.singleDomainToolStripMenuItem.Name = "singleDomainToolStripMenuItem";
+            this.singleDomainToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.singleDomainToolStripMenuItem.Tag = "Single";
+            this.singleDomainToolStripMenuItem.Text = "Single";
+            // 
+            // multipleDomainToolStripMenuItem
+            // 
+            this.multipleDomainToolStripMenuItem.Name = "multipleDomainToolStripMenuItem";
+            this.multipleDomainToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.multipleDomainToolStripMenuItem.Tag = "Multiple";
+            this.multipleDomainToolStripMenuItem.Text = "Multiple";
             // 
             // toolStripMenuItem3
             // 
@@ -318,7 +387,7 @@ namespace NUnit.Gui.Views
             this.toolStripMenuItem8,
             this.statusBarToolStripMenuItem});
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
-            this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 22);
             this.viewToolStripMenuItem.Text = "&View";
             // 
             // fullGuiToolStripMenuItem
@@ -449,7 +518,7 @@ namespace NUnit.Gui.Views
             this.editToolStripMenuItem,
             this.notYetImplementedToolStripMenuItem});
             this.projectToolStripMenuItem.Name = "projectToolStripMenuItem";
-            this.projectToolStripMenuItem.Size = new System.Drawing.Size(56, 20);
+            this.projectToolStripMenuItem.Size = new System.Drawing.Size(56, 22);
             this.projectToolStripMenuItem.Text = "&Project";
             // 
             // configurationsToolStripMenuItem
@@ -523,7 +592,7 @@ namespace NUnit.Gui.Views
             this.toolStripMenuItem15,
             this.addinsToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 22);
             this.toolsToolStripMenuItem.Text = "T&ools";
             // 
             // testAssembliesToolStripMenuItem
@@ -577,7 +646,7 @@ namespace NUnit.Gui.Views
             this.toolStripMenuItem5,
             this.aboutNUnitToolStripMenuItem});
             this.heopToolStripMenuItem.Name = "heopToolStripMenuItem";
-            this.heopToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.heopToolStripMenuItem.Size = new System.Drawing.Size(44, 22);
             this.heopToolStripMenuItem.Text = "&Help";
             // 
             // nUnitHelpToolStripMenuItem
@@ -609,14 +678,16 @@ namespace NUnit.Gui.Views
             this.heopToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(488, 24);
-            this.menuStrip1.TabIndex = 0;
+            this.menuStrip1.Padding = new System.Windows.Forms.Padding(4, 1, 0, 1);
+            this.menuStrip1.Size = new System.Drawing.Size(529, 24);
+            this.menuStrip1.TabIndex = 1;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // splitContainer1
             // 
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.Location = new System.Drawing.Point(0, 24);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(2);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -627,31 +698,10 @@ namespace NUnit.Gui.Views
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.tabControl1);
-            this.splitContainer1.Size = new System.Drawing.Size(488, 214);
-            this.splitContainer1.SplitterDistance = 162;
+            this.splitContainer1.Size = new System.Drawing.Size(529, 370);
+            this.splitContainer1.SplitterDistance = 175;
+            this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 4;
-            // 
-            // testTreeView
-            // 
-            this.testTreeView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.testTreeView.Location = new System.Drawing.Point(0, 61);
-            this.testTreeView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.testTreeView.Name = "testTreeView";
-            this.testTreeView.Size = new System.Drawing.Size(162, 153);
-            this.testTreeView.TabIndex = 2;
-            // 
-            // progressBarView
-            // 
-            this.progressBarView.AutoSize = true;
-            this.progressBarView.BackColor = System.Drawing.SystemColors.Control;
-            this.progressBarView.Dock = System.Windows.Forms.DockStyle.Top;
-            this.progressBarView.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.progressBarView.Location = new System.Drawing.Point(0, 0);
-            this.progressBarView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.progressBarView.Name = "progressBarView";
-            this.progressBarView.Size = new System.Drawing.Size(162, 61);
-            this.progressBarView.Status = NUnit.UiKit.Controls.TestProgressBarStatus.Success;
-            this.progressBarView.TabIndex = 1;
             // 
             // tabControl1
             // 
@@ -661,22 +711,70 @@ namespace NUnit.Gui.Views
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage2);
-            this.tabControl1.Location = new System.Drawing.Point(0, 12);
+            this.tabControl1.Location = new System.Drawing.Point(0, 8);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(320, 202);
+            this.tabControl1.Size = new System.Drawing.Size(349, 362);
             this.tabControl1.TabIndex = 1;
             // 
             // tabPage2
             // 
             this.tabPage2.Controls.Add(this.xmlView);
             this.tabPage2.Location = new System.Drawing.Point(4, 4);
+            this.tabPage2.Margin = new System.Windows.Forms.Padding(2);
             this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(312, 176);
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(2);
+            this.tabPage2.Size = new System.Drawing.Size(341, 342);
             this.tabPage2.TabIndex = 4;
             this.tabPage2.Text = "XML";
             this.tabPage2.UseVisualStyleBackColor = true;
+            // 
+            // testTreeView
+            // 
+            this.testTreeView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.testTreeView.Location = new System.Drawing.Point(0, 27);
+            this.testTreeView.Name = "testTreeView";
+            this.testTreeView.Size = new System.Drawing.Size(175, 343);
+            this.testTreeView.TabIndex = 0;
+            // 
+            // progressBarView
+            // 
+            this.progressBarView.AutoSize = true;
+            this.progressBarView.BackColor = System.Drawing.SystemColors.Control;
+            this.progressBarView.Dock = System.Windows.Forms.DockStyle.Top;
+            this.progressBarView.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.progressBarView.Location = new System.Drawing.Point(0, 0);
+            this.progressBarView.Name = "progressBarView";
+            this.progressBarView.Size = new System.Drawing.Size(175, 27);
+            this.progressBarView.Status = NUnit.UiKit.Controls.TestProgressBarStatus.Success;
+            this.progressBarView.TabIndex = 1;
+            // 
+            // propertiesView
+            // 
+            this.propertiesView.AssertCount = "";
+            this.propertiesView.AutoScroll = true;
+            this.propertiesView.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.propertiesView.Categories = "";
+            this.propertiesView.Description = "";
+            this.propertiesView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.propertiesView.ElapsedTime = "";
+            this.propertiesView.FullName = "";
+            this.propertiesView.Header = "";
+            this.propertiesView.Location = new System.Drawing.Point(2, 2);
+            this.propertiesView.Message = "";
+            this.propertiesView.Name = "propertiesView";
+            this.propertiesView.Outcome = "";
+            this.propertiesView.Output = "";
+            this.propertiesView.Padding = new System.Windows.Forms.Padding(0, 3, 0, 0);
+            this.propertiesView.Properties = "";
+            this.propertiesView.RunState = "";
+            this.propertiesView.Size = new System.Drawing.Size(337, 332);
+            this.propertiesView.SkipReason = "";
+            this.propertiesView.StackTrace = "";
+            this.propertiesView.TabIndex = 2;
+            this.propertiesView.TestCount = "";
+            this.propertiesView.TestType = "";
             // 
             // xmlView
             // 
@@ -684,25 +782,35 @@ namespace NUnit.Gui.Views
             this.xmlView.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.xmlView.Dock = System.Windows.Forms.DockStyle.Fill;
             this.xmlView.Header = "";
-            this.xmlView.Location = new System.Drawing.Point(3, 3);
-            this.xmlView.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.xmlView.Location = new System.Drawing.Point(2, 2);
+            this.xmlView.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.xmlView.Name = "xmlView";
-            this.xmlView.Padding = new System.Windows.Forms.Padding(0, 4, 0, 0);
-            this.xmlView.Size = new System.Drawing.Size(306, 170);
+            this.xmlView.Padding = new System.Windows.Forms.Padding(0, 3, 0, 0);
+            this.xmlView.Size = new System.Drawing.Size(337, 338);
             this.xmlView.TabIndex = 2;
             this.xmlView.TestXml = null;
+            // 
+            // statusBarView
+            // 
+            this.statusBarView.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.statusBarView.Location = new System.Drawing.Point(0, 394);
+            this.statusBarView.Name = "statusBarView";
+            this.statusBarView.Size = new System.Drawing.Size(529, 22);
+            this.statusBarView.TabIndex = 2;
+            this.toolTip1.SetToolTip(this.statusBarView, "Name of the currently executing or selected test plus stats about it.");
             // 
             // MainForm
             // 
             this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(488, 262);
+            this.ClientSize = new System.Drawing.Size(529, 416);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.statusBarView);
             this.Controls.Add(this.menuStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
+            this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "MainForm";
             this.Text = "NUnit";
             this.tabPage1.ResumeLayout(false);
@@ -716,7 +824,7 @@ namespace NUnit.Gui.Views
             this.tabPage2.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
-            this.DragEnter += MainForm_DragEnter;
+
         }
 
         private void MainForm_DragEnter(object sender, DragEventArgs e)
@@ -743,8 +851,6 @@ namespace NUnit.Gui.Views
         private System.Windows.Forms.ToolStripMenuItem saveResultsToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
         private System.Windows.Forms.ToolStripMenuItem reloadTestsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem selectRuntimeToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem dummyToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem3;
         private System.Windows.Forms.ToolStripMenuItem recentProjectsToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem4;
@@ -793,8 +899,22 @@ namespace NUnit.Gui.Views
         private TestTreeView testTreeView;
         private TestPropertiesView propertiesView;
         private System.Windows.Forms.TabPage tabPage2;
-        private System.Windows.Forms.ToolStripMenuItem notYetImplementedToolStripMenuItem;
         private XmlView xmlView;
+        private ToolStripSeparator toolStripSeparator1;
+        private ToolStripMenuItem selectRuntimeToolStripMenuItem;
+        private ToolStripMenuItem defaultRuntimeToolStripMenuItem;
+        private ToolStripMenuItem processModelToolStripMenuItem1;
+        private ToolStripMenuItem defaultProcessToolStripMenuItem;
+        private ToolStripMenuItem inProcessToolStripMenuItem;
+        private ToolStripMenuItem singleProcessToolStripMenuItem;
+        private ToolStripMenuItem multipleProcessToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator2;
+        private ToolStripMenuItem loadAsX86ToolStripMenuItem;
+        private ToolStripMenuItem domainUsageToolStripMenuItem1;
+        private ToolStripMenuItem defaultDomainToolStripMenuItem;
+        private ToolStripMenuItem singleDomainToolStripMenuItem;
+        private ToolStripMenuItem multipleDomainToolStripMenuItem;
+        private ToolStripMenuItem notYetImplementedToolStripMenuItem;
     }
 }
 

--- a/src/nunit-gui/Views/MainForm.cs
+++ b/src/nunit-gui/Views/MainForm.cs
@@ -53,6 +53,7 @@ namespace NUnit.Gui.Views
                 defaultProcessToolStripMenuItem, inProcessToolStripMenuItem, singleProcessToolStripMenuItem, multipleProcessToolStripMenuItem);
             DomainUsage = new CheckedMenuGroup("domainUsage",
                 defaultDomainToolStripMenuItem, singleDomainToolStripMenuItem, multipleDomainToolStripMenuItem);
+            RunAsX86 = new MenuElement(loadAsX86ToolStripMenuItem);
             RecentProjectsMenu = new MenuElement(recentProjectsToolStripMenuItem);
             ExitCommand = new MenuElement(exitToolStripMenuItem);
 
@@ -97,11 +98,7 @@ namespace NUnit.Gui.Views
         public IMenu SelectRuntimeMenu { get; private set; }
         public ISelection SelectedRuntime { get; private set; }
         public ISelection ProcessModel { get; private set; }
-        public bool LoadAsX86
-        {
-            get { return loadAsX86ToolStripMenuItem.Checked; }
-            set { loadAsX86ToolStripMenuItem.Checked = value; }
-        }
+        public IChecked RunAsX86 { get; private set; }
         public ISelection DomainUsage { get; private set; }
         public IMenu RecentProjectsMenu { get; private set; }
         public ICommand ExitCommand { get; private set; }

--- a/src/nunit-gui/Views/MainForm.cs
+++ b/src/nunit-gui/Views/MainForm.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System.Windows.Forms;
+using NUnit.UiKit;
 using NUnit.UiKit.Elements;
 
 namespace NUnit.Gui.Views
@@ -37,6 +38,7 @@ namespace NUnit.Gui.Views
 
         private void InitializeViewElements()
         {
+            // File Menu
             FileMenu = new MenuElement(fileToolStripMenuItem);
             NewProjectCommand = new MenuElement(newProjectToolStripMenuItem);
             OpenProjectCommand = new MenuElement(openProjectToolStripMenuItem);
@@ -46,20 +48,29 @@ namespace NUnit.Gui.Views
             SaveResultsCommand = new MenuElement(saveResultsToolStripMenuItem);
             ReloadTestsCommand = new MenuElement(reloadTestsToolStripMenuItem);
             SelectRuntimeMenu = new MenuElement(selectRuntimeToolStripMenuItem);
+            SelectedRuntime = new CheckedMenuGroup(selectRuntimeToolStripMenuItem);
+            ProcessModel = new CheckedMenuGroup("processModel",
+                defaultProcessToolStripMenuItem, inProcessToolStripMenuItem, singleProcessToolStripMenuItem, multipleProcessToolStripMenuItem);
+            DomainUsage = new CheckedMenuGroup("domainUsage",
+                defaultDomainToolStripMenuItem, singleDomainToolStripMenuItem, multipleDomainToolStripMenuItem);
             RecentProjectsMenu = new MenuElement(recentProjectsToolStripMenuItem);
             ExitCommand = new MenuElement(exitToolStripMenuItem);
 
+            // View Menu
             FullGuiCommand = new MenuElement(fullGuiToolStripMenuItem);
             MiniGuiCommand = new MenuElement(miniGuiToolStripMenuItem);
             GuiFontCommand = new MenuElement(guiFontToolStripMenuItem);
             FixedFontCommand = new MenuElement(fixedFontToolStripMenuItem);
             StatusBarCommand = new MenuElement(statusBarToolStripMenuItem);
 
+            // Project Menu
             ProjectMenu = new MenuElement(projectToolStripMenuItem);
 
+            // Tools Menu
             SettingsCommand = new MenuElement(settingsToolStripMenuItem);
             AddinsCommand = new MenuElement(addinsToolStripMenuItem);
 
+            // Help Menu
             NUnitHelpCommand = new MenuElement(nUnitHelpToolStripMenuItem);
             AboutNUnitCommand = new MenuElement(aboutNUnitToolStripMenuItem);
 
@@ -67,6 +78,7 @@ namespace NUnit.Gui.Views
             TestName = new ControlElement<Label>(testName);
 
             DialogManager = new DialogManager();
+            MessageDisplay = new MessageDisplay();
         }
 
         #region Public Properties
@@ -74,7 +86,7 @@ namespace NUnit.Gui.Views
         #region IMainView Members
 
         // File Menu
-        public IPopup FileMenu { get; private set; }
+        public IMenu FileMenu { get; private set; }
         public ICommand NewProjectCommand { get; private set; }
         public ICommand OpenProjectCommand { get; private set; }
         public ICommand CloseCommand { get; private set; }
@@ -82,8 +94,16 @@ namespace NUnit.Gui.Views
         public ICommand SaveAsCommand { get; private set; }
         public ICommand SaveResultsCommand { get; private set; }
         public ICommand ReloadTestsCommand { get; private set; }
-        public IPopup SelectRuntimeMenu { get; private set; }
-        public IPopup RecentProjectsMenu { get; private set; }
+        public IMenu SelectRuntimeMenu { get; private set; }
+        public ISelection SelectedRuntime { get; private set; }
+        public ISelection ProcessModel { get; private set; }
+        public bool LoadAsX86
+        {
+            get { return loadAsX86ToolStripMenuItem.Checked; }
+            set { loadAsX86ToolStripMenuItem.Checked = value; }
+        }
+        public ISelection DomainUsage { get; private set; }
+        public IMenu RecentProjectsMenu { get; private set; }
         public ICommand ExitCommand { get; private set; }
 
         // View Menu
@@ -94,7 +114,7 @@ namespace NUnit.Gui.Views
         public ICommand StatusBarCommand { get; private set; }
 
         // Project Menu
-        public IPopup ProjectMenu { get; private set; }
+        public IMenu ProjectMenu { get; private set; }
 
         // Tools Menu
         public ICommand SettingsCommand { get; private set; }
@@ -108,6 +128,7 @@ namespace NUnit.Gui.Views
         public IViewElement TestName { get; private set; }
 
         public IDialogManager DialogManager { get; private set; }
+        public IMessageDisplay MessageDisplay { get; private set; }
 
         #endregion
 

--- a/src/nunit-gui/Views/TestTreeView.cs
+++ b/src/nunit-gui/Views/TestTreeView.cs
@@ -85,7 +85,7 @@ namespace NUnit.Gui.Views
         public ICommand CollapseAllCommand { get; private set; }
         public ICommand CollapseToFixturesCommand { get; private set; }
 
-        public IToolStripElement<ToolStripDropDownButton> FormatButton { get; private set; }
+        public IToolStripElement FormatButton { get; private set; }
         public ISelection DisplayFormat { get; private set; }
         public ISelection GroupBy { get; private set; }
 

--- a/src/nunit-gui/Views/XmlView.cs
+++ b/src/nunit-gui/Views/XmlView.cs
@@ -34,8 +34,8 @@ namespace NUnit.Gui.Views
         string Header { get; set; }
         IViewElement XmlPanel { get; }
         IControlElement<RichTextBox> XmlTextBox { get; }
-        IToolStripElement<ToolStripMenuItem> CopyToolStripMenuItem { get; }
-        IToolStripElement<ToolStripMenuItem> WordWrapToolStripMenuItem { get; }
+        IMenu CopyToolStripMenuItem { get; }
+        IMenu WordWrapToolStripMenuItem { get; }
         XmlNode TestXml { get; set; }
         event CommandHandler SelectAllCommand;
         event CommandHandler SelectionChanged;
@@ -57,8 +57,8 @@ namespace NUnit.Gui.Views
 
             XmlPanel = new ControlElement<Panel>(xmlPanel);
             XmlTextBox = new ControlElement<RichTextBox>(xmlTextBox);
-            CopyToolStripMenuItem = new ToolStripElement<ToolStripMenuItem>(copyToolStripMenuItem);
-            WordWrapToolStripMenuItem = new ToolStripElement<ToolStripMenuItem>(wordWrapToolStripMenuItem);
+            CopyToolStripMenuItem = new MenuElement(copyToolStripMenuItem);
+            WordWrapToolStripMenuItem = new MenuElement(wordWrapToolStripMenuItem);
             selectAllToolStripMenuItem.Click += (s, a) =>
             {
                 if (SelectAllCommand != null)
@@ -95,9 +95,9 @@ namespace NUnit.Gui.Views
 
         public IControlElement<RichTextBox> XmlTextBox { get; private set; }
 
-        public IToolStripElement<ToolStripMenuItem> CopyToolStripMenuItem { get; private set; }
+        public IMenu CopyToolStripMenuItem { get; private set; }
 
-        public IToolStripElement<ToolStripMenuItem> WordWrapToolStripMenuItem { get; private set; }
+        public IMenu WordWrapToolStripMenuItem { get; private set; }
 
         public XmlNode TestXml
         {

--- a/src/nunit.uikit/Elements/CheckedMenuGroup.cs
+++ b/src/nunit.uikit/Elements/CheckedMenuGroup.cs
@@ -114,8 +114,10 @@ namespace NUnit.UiKit.Elements
             }
         }
 
-        public string Name { get; private set; }
+        public string Name { get; }
+
         public string Text { get; set; }
+
         public int SelectedIndex
         {
             get

--- a/src/nunit.uikit/Elements/IMenu.cs
+++ b/src/nunit.uikit/Elements/IMenu.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2016 Charlie Poole
+// Copyright (c) 2017 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -22,33 +22,14 @@
 // ***********************************************************************
 
 using System.Windows.Forms;
-using NUnit.UiKit.Elements;
 
-namespace NUnit.Gui.Views
+namespace NUnit.UiKit.Elements
 {
-    // Interface used for testing
-    public interface ITestTreeView : IView
+    /// <summary>
+    /// IMenu is implemented by MenuElements
+    /// </summary>
+    public interface IMenu : IToolStripElement, ICommand, IPopup, IChecked
     {
-        ICommand RunButton { get; }
-        ICommand RunAllCommand { get; }
-        ICommand RunSelectedCommand { get; }
-        ICommand RunFailedCommand { get; }
-        ICommand StopRunCommand { get; }
-
-        IToolStripElement FormatButton { get; }
-        ISelection DisplayFormat { get; }
-        ISelection GroupBy { get; }
-
-        ICommand RunContextCommand { get; }
-        ICommand RunCheckedCommand { get; }
-        IChecked ShowCheckBoxesCommand { get; }
-        ICommand ExpandAllCommand { get; }
-        ICommand CollapseAllCommand { get; }
-        ICommand CollapseToFixturesCommand { get; }
-
-        void ExpandAll();
-        void CollapseAll();
-
-        ITreeViewElement Tree { get; }
+        ToolStripItemCollection DropDownItems { get; }
     }
 }

--- a/src/nunit.uikit/Elements/IPopup.cs
+++ b/src/nunit.uikit/Elements/IPopup.cs
@@ -29,7 +29,7 @@ namespace NUnit.UiKit.Elements
     /// The IPopup interface is implemented by a menu item,
     /// which displays subordinate items.
     /// </summary>
-    public interface IPopup : IToolStripElement<ToolStripMenuItem>
+    public interface IPopup : IToolStripElement
     {
         /// <summary>
         /// Popup event is raised to signal the presenter

--- a/src/nunit.uikit/Elements/ISelection.cs
+++ b/src/nunit.uikit/Elements/ISelection.cs
@@ -43,6 +43,11 @@ namespace NUnit.UiKit.Elements
         string SelectedItem { get; set; }
 
         /// <summary>
+        /// Refresh selection if possible, otherwise noop
+        /// </summary>
+        void Refresh();
+
+        /// <summary>
         /// Event raised when the selection is changed by the user
         /// </summary>
         event CommandHandler SelectionChanged;

--- a/src/nunit.uikit/Elements/IToolStripElement.cs
+++ b/src/nunit.uikit/Elements/IToolStripElement.cs
@@ -26,11 +26,10 @@ using System.Windows.Forms;
 namespace NUnit.UiKit.Elements
 {
     /// <summary>
-    /// IControlElement is implemented by elements that wrap ToolStripItems.
+    /// IToolStripElement is implemented by elements that wrap ToolStripItems.
     /// </summary>
-    public interface IToolStripElement<T> : IViewElement where T : ToolStripItem
+    public interface IToolStripElement : IViewElement
     {
-        T ToolStripItem { get; }
         string ToolTipText { get; set; }
     }
 }

--- a/src/nunit.uikit/Elements/MenuElement.cs
+++ b/src/nunit.uikit/Elements/MenuElement.cs
@@ -29,7 +29,7 @@ namespace NUnit.UiKit.Elements
     /// MenuElement is the implementation of ToolStripItem 
     /// used in the actual application.
     /// </summary>
-    public class MenuElement : ToolStripElement<ToolStripMenuItem>, ICommand, IPopup, IChecked
+    public class MenuElement : ToolStripElement<ToolStripMenuItem>, IMenu
     {
         public event CommandHandler Execute;
         public event CommandHandler Popup;
@@ -63,6 +63,11 @@ namespace NUnit.UiKit.Elements
                     });
                 }
             }
+        }
+
+        public ToolStripItemCollection DropDownItems
+        {
+            get { return ToolStripItem.DropDown.Items; }
         }
     }
 }

--- a/src/nunit.uikit/Elements/ToolStripElement.cs
+++ b/src/nunit.uikit/Elements/ToolStripElement.cs
@@ -28,7 +28,7 @@ namespace NUnit.UiKit.Elements
     /// <summary>
     /// ToolStripItem is a generic wrapper for ToolStripItems
     /// </summary>
-    public class ToolStripElement<T> : IToolStripElement<T> where T : ToolStripItem
+    public class ToolStripElement<T> : IToolStripElement where T : ToolStripItem
     {
         public ToolStripElement(T toolStripItem)
         {

--- a/src/nunit.uikit/IMessageDisplay.cs
+++ b/src/nunit.uikit/IMessageDisplay.cs
@@ -29,19 +29,27 @@ namespace NUnit.UiKit
     public interface IMessageDisplay
     {
         DialogResult Display(string message);
+        DialogResult Display(string message, string caption);
         DialogResult Display(string message, MessageBoxButtons buttons);
+        DialogResult Display(string message, string caption, MessageBoxButtons buttons);
 
         DialogResult Error(string message);
+        DialogResult Error(string message, string caption);
         DialogResult Error(string message, MessageBoxButtons buttons);
+        DialogResult Error(string message, string caption, MessageBoxButtons buttons);
         DialogResult Error(string message, Exception exception);
         DialogResult Error(string message, Exception exception, MessageBoxButtons buttons);
 
         DialogResult FatalError(string message, Exception exception);
 
         DialogResult Info(string message);
+        DialogResult Info(string message, string caption);
         DialogResult Info(string message, MessageBoxButtons buttons);
+        DialogResult Info(string message, string caption, MessageBoxButtons buttons);
 
         DialogResult Ask(string message);
+        DialogResult Ask(string message, string caption);
         DialogResult Ask(string message, MessageBoxButtons buttons);
+        DialogResult Ask(string message, string caption, MessageBoxButtons buttons);
     }
 }

--- a/src/nunit.uikit/MessageDisplay.cs
+++ b/src/nunit.uikit/MessageDisplay.cs
@@ -40,7 +40,7 @@ namespace NUnit.UiKit
 
         public MessageDisplay(string caption)
         {
-            this._defaultCaption = caption;
+            _defaultCaption = caption;
         }
 
         #region Public Methods
@@ -59,7 +59,7 @@ namespace NUnit.UiKit
 
         public DialogResult Display(string message, MessageBoxButtons buttons)
         {
-            return MessageBox.Show(message, _defaultCaption, buttons);
+            return Display(message, _defaultCaption, buttons);
         }
 
         public DialogResult Display(string message, string caption, MessageBoxButtons buttons)
@@ -83,7 +83,7 @@ namespace NUnit.UiKit
 
         public DialogResult Error(string message, MessageBoxButtons buttons)
         {
-            return MessageBox.Show(message, _defaultCaption, buttons);
+            return Error(message, _defaultCaption, buttons);
         }
 
         public DialogResult Error(string message, string caption, MessageBoxButtons buttons)

--- a/src/nunit.uikit/MessageDisplay.cs
+++ b/src/nunit.uikit/MessageDisplay.cs
@@ -34,13 +34,13 @@ namespace NUnit.UiKit
     {
         private static readonly string DEFAULT_CAPTION = "NUnit";
 
-        private readonly string caption;
+        private readonly string _defaultCaption;
 
         public MessageDisplay() : this(DEFAULT_CAPTION) { }
 
         public MessageDisplay(string caption)
         {
-            this.caption = caption;
+            this._defaultCaption = caption;
         }
 
         #region Public Methods
@@ -49,10 +49,20 @@ namespace NUnit.UiKit
 
         public DialogResult Display(string message)
         {
-            return Display(message, MessageBoxButtons.OK);
+            return Display(message, _defaultCaption, MessageBoxButtons.OK);
+        }
+
+        public DialogResult Display(string message, string caption)
+        {
+            return Display(message, caption, MessageBoxButtons.OK);
         }
 
         public DialogResult Display(string message, MessageBoxButtons buttons)
+        {
+            return MessageBox.Show(message, _defaultCaption, buttons);
+        }
+
+        public DialogResult Display(string message, string caption, MessageBoxButtons buttons)
         {
             return MessageBox.Show(message, caption, buttons, MessageBoxIcon.None);
         }
@@ -61,12 +71,22 @@ namespace NUnit.UiKit
 
         #region Error
 
-        public DialogResult Error( string message )
+        public DialogResult Error(string message)
         {
-            return Error(message, MessageBoxButtons.OK);
+            return Error(message, _defaultCaption, MessageBoxButtons.OK);
+        }
+
+        public DialogResult Error(string message, string caption)
+        {
+            return Error(message, caption, MessageBoxButtons.OK);
         }
 
         public DialogResult Error(string message, MessageBoxButtons buttons)
+        {
+            return MessageBox.Show(message, _defaultCaption, buttons);
+        }
+
+        public DialogResult Error(string message, string caption, MessageBoxButtons buttons)
         {
             return MessageBox.Show(message, caption, buttons, MessageBoxIcon.Stop);
         }
@@ -95,7 +115,17 @@ namespace NUnit.UiKit
             return Info(message, MessageBoxButtons.OK);
         }
 
+        public DialogResult Info(string message, string caption)
+        {
+            return Info(message, caption, MessageBoxButtons.OK);
+        }
+
         public DialogResult Info(string message, MessageBoxButtons buttons)
+        {
+            return Info(message, _defaultCaption, buttons);
+        }
+
+        public DialogResult Info(string message, string caption, MessageBoxButtons buttons)
         {
             return MessageBox.Show(message, caption, buttons, MessageBoxIcon.Information);
         }
@@ -106,10 +136,20 @@ namespace NUnit.UiKit
 
         public DialogResult Ask(string message)
         {
-            return Ask(message, MessageBoxButtons.YesNo);
+            return Ask(message, _defaultCaption, MessageBoxButtons.YesNo);
+        }
+
+        public DialogResult Ask(string message, string caption)
+        {
+            return Ask(message, caption, MessageBoxButtons.YesNo);
         }
 
         public DialogResult Ask(string message, MessageBoxButtons buttons)
+        {
+            return Ask(message, _defaultCaption, buttons);
+        }
+
+        public DialogResult Ask(string message, string caption, MessageBoxButtons buttons)
         {
             return MessageBox.Show(message, caption, buttons, MessageBoxIcon.Question);
         }

--- a/src/nunit.uikit/nunit.uikit.csproj
+++ b/src/nunit.uikit/nunit.uikit.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Elements\ICommand.cs" />
     <Compile Include="Elements\IPopup.cs" />
     <Compile Include="Elements\IChecked.cs" />
+    <Compile Include="Elements\IMenu.cs" />
     <Compile Include="Elements\ITreeViewElement.cs" />
     <Compile Include="Elements\IToolStripElement.cs" />
     <Compile Include="Elements\IControlElement.cs" />

--- a/src/tests/Model/TestModelAssemblyTests.cs
+++ b/src/tests/Model/TestModelAssemblyTests.cs
@@ -30,7 +30,7 @@ namespace NUnit.Gui.Model
     using Tests.Assemblies;
 
     [Explicit("Second TestEngine conflicts with main engine")]
-    public class TestModelTests
+    public class TestModelAssemblyTests
     {
         private const string MOCK_ASSEMBLY = "mock-assembly.dll";
 

--- a/src/tests/Model/TestModelPackageTests.cs
+++ b/src/tests/Model/TestModelPackageTests.cs
@@ -1,0 +1,64 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Linq;
+using NSubstitute;
+using NUnit.Engine;
+using NUnit.Framework;
+
+namespace NUnit.Gui.Model
+{
+    public class TestModelPackageTests
+    {
+        private TestModel _model;
+
+        [SetUp]
+        public void CreateModel()
+        {
+            var engine = Substitute.For<ITestEngine>();
+            var options = new CommandLineOptions();
+            _model = new TestModel(engine, options);
+        }
+
+        [TestCase("my.test.assembly.dll")]
+        [TestCase("one.dll", "two.dll", "three.dll")]
+        public void PackageContainsOneSubPackagePerAssembly(params string[] assemblies)
+        {
+            TestPackage package = _model.MakeTestPackage(assemblies);
+
+            Assert.That(package.SubPackages.Select(p => p.Name), Is.EqualTo(assemblies));
+        }
+
+        [TestCase("ProjectModel", "Single")]
+        [TestCase("DomainUsage", "Multiple")]
+        [TestCase("RuntimeFramework", "net-2.0")]
+        public void PackageReflectsPackageSettings(string key , object value)
+        {
+            _model.PackageSettings[key] = value;
+            TestPackage package = _model.MakeTestPackage(new[] { "my.dll" });
+
+            Assert.That(package.Settings.ContainsKey(key));
+            Assert.That(package.Settings[key], Is.EqualTo(value));
+        }
+    }
+}

--- a/src/tests/Presenters/Main/PackageSettingsTests.cs
+++ b/src/tests/Presenters/Main/PackageSettingsTests.cs
@@ -73,7 +73,7 @@ namespace NUnit.Gui.Presenters.Main
 
             Model.PackageSettings.Received(1).Remove("DomainUsage");
         }
-        
+
         [TestCase("net-2.0")]
         [TestCase("net-4.5")]
         [TestCase("INVALID", Description = "Invalid Setting is passed on to the model")]

--- a/src/tests/Presenters/Main/PackageSettingsTests.cs
+++ b/src/tests/Presenters/Main/PackageSettingsTests.cs
@@ -1,0 +1,108 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NSubstitute;
+using NUnit.Framework;
+using NUnit.UiKit.Elements;
+
+namespace NUnit.Gui.Presenters.Main
+{
+    public class PackageSettingsTests : MainPresenterTestBase
+    {
+        [TestCase("Single")]
+        [TestCase("Multiple")]
+        [TestCase("InProcess")]
+        [TestCase("INVALID", Description = "Invalid Setting is passed on to the model")]
+        public void ProcessModel_SettingChanged(string value)
+        {
+            View.ProcessModel.SelectedItem.Returns(value);
+
+            View.ProcessModel.SelectionChanged += Raise.Event<CommandHandler>();
+
+            Model.PackageSettings.Received(1)["ProcessModel"] = value;
+        }
+
+        [Test]
+        public void ProcessModel_SetToDefault()
+        {
+            View.ProcessModel.SelectedItem.Returns("DEFAULT");
+
+            View.ProcessModel.SelectionChanged += Raise.Event<CommandHandler>();
+
+            Model.PackageSettings.Received(1).Remove("ProcessModel");
+        }
+
+        [TestCase("Single")]
+        [TestCase("Multiple")]
+        [TestCase("INVALID", Description = "Invalid Setting is passed on to the model")]
+        public void DomainUsage_SettingChanged(string value)
+        {
+            View.DomainUsage.SelectedItem.Returns(value);
+
+            View.DomainUsage.SelectionChanged += Raise.Event<CommandHandler>();
+
+            Model.PackageSettings.Received(1)["DomainUsage"] = value;
+        }
+
+        [Test]
+        public void DomainUsage_SetToDefault()
+        {
+            View.DomainUsage.SelectedItem.Returns("DEFAULT");
+
+            View.DomainUsage.SelectionChanged += Raise.Event<CommandHandler>();
+
+            Model.PackageSettings.Received(1).Remove("DomainUsage");
+        }
+        
+        [TestCase("net-2.0")]
+        [TestCase("net-4.5")]
+        [TestCase("INVALID", Description = "Invalid Setting is passed on to the model")]
+        [TestCase("net-2.0", "net-4.5")]
+        public void SelectedRuntime_SettingChanged(params string[] settings)
+        {
+            foreach (var setting in settings)
+            {
+                View.SelectedRuntime.SelectedItem.Returns(setting);
+
+                View.SelectedRuntime.SelectionChanged += Raise.Event<CommandHandler>();
+
+                Model.PackageSettings.Received(1)["RuntimeFramework"] = setting;
+            }
+        }
+
+        public void SelectedRuntime_MultipleChanges()
+        {
+
+        }
+
+        [Test]
+        public void SelectedRuntime_SetToDefault()
+        {
+            View.SelectedRuntime.SelectedItem.Returns("DEFAULT");
+
+            View.SelectedRuntime.SelectionChanged += Raise.Event<CommandHandler>();
+
+            Model.PackageSettings.Received(1).Remove("RuntimeFramework");
+        }
+    }
+}

--- a/src/tests/Presenters/Main/WhenPresenterIsCreated.cs
+++ b/src/tests/Presenters/Main/WhenPresenterIsCreated.cs
@@ -73,12 +73,6 @@ namespace NUnit.Gui.Presenters.Main
         }
 
         [Test]
-        public void SelectRuntime_IsDisabled()
-        {
-            View.SelectRuntimeMenu.Received(1).Enabled = false;
-        }
-
-        [Test]
         public void RecentProjects_IsEnabled()
         {
             View.RecentProjectsMenu.Received(1).Enabled = true;

--- a/src/tests/Presenters/Main/WhenTestRunBegins.cs
+++ b/src/tests/Presenters/Main/WhenTestRunBegins.cs
@@ -83,12 +83,6 @@ namespace NUnit.Gui.Presenters.Main
         }
 
         [Test]
-        public void SelectRuntimeMenu_IsDisabled()
-        {
-            Assert.That(View.SelectRuntimeMenu.Enabled == false);
-        }
-
-        [Test]
         public void RecentProjects_IsDisabled()
         {
             Assert.That(View.RecentProjectsMenu.Enabled == false);

--- a/src/tests/Presenters/Main/WhenTestRunCompletes.cs
+++ b/src/tests/Presenters/Main/WhenTestRunCompletes.cs
@@ -86,12 +86,6 @@ namespace NUnit.Gui.Presenters.Main
         }
 
         [Test]
-        public void SelectRuntimeMenu_IsEnabled()
-        {
-            View.SelectRuntimeMenu.Received().Enabled = true;
-        }
-
-        [Test]
         public void RecentProjects_IsEnabled()
         {
             View.RecentProjectsMenu.Received().Enabled = true;

--- a/src/tests/Presenters/Main/WhenTestsAreLoaded.cs
+++ b/src/tests/Presenters/Main/WhenTestsAreLoaded.cs
@@ -30,7 +30,7 @@ namespace NUnit.Gui.Presenters.Main
     using Model;
     using Views;
 
-    public class WhenTestsAreReloaded : MainPresenterTestBase
+    public class WhenTestsAreLoaded : MainPresenterTestBase
     {
         [SetUp]
         public void SimulateTestReload()
@@ -42,7 +42,7 @@ namespace NUnit.Gui.Presenters.Main
             doc.LoadXml("<test-suite id='1'/>");
             TestNode testNode = new TestNode(doc.FirstChild);
             Model.Tests.Returns(testNode);
-            Model.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, testNode));
+            Model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
         }
 
 #if NYI
@@ -87,12 +87,6 @@ namespace NUnit.Gui.Presenters.Main
         public void ReloadTests_IsEnabled()
         {
             View.ReloadTestsCommand.Received().Enabled = true;
-        }
-
-        [Test]
-        public void SelectRuntimeMenu_IsEnabled()
-        {
-            View.SelectRuntimeMenu.Received().Enabled = true;
         }
 
         [Test]

--- a/src/tests/Presenters/Main/WhenTestsAreReloaded.cs
+++ b/src/tests/Presenters/Main/WhenTestsAreReloaded.cs
@@ -30,7 +30,7 @@ namespace NUnit.Gui.Presenters.Main
     using Model;
     using Views;
 
-    public class WhenTestsAreLoaded : MainPresenterTestBase
+    public class WhenTestsAreReloaded : MainPresenterTestBase
     {
         [SetUp]
         public void SimulateTestLoad()
@@ -42,7 +42,7 @@ namespace NUnit.Gui.Presenters.Main
             doc.LoadXml("<test-suite id='1'/>");
             TestNode testNode = new TestNode(doc.FirstChild);
             Model.Tests.Returns(testNode);
-            Model.TestLoaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestLoaded, testNode));
+            Model.TestReloaded += Raise.Event<TestNodeEventHandler>(new TestNodeEventArgs(TestAction.TestReloaded, testNode));
         }
 
 #if NYI
@@ -90,9 +90,15 @@ namespace NUnit.Gui.Presenters.Main
         }
 
         [Test]
-        public void SelectRuntimeMenu_IsEnabled()
+        public void ProcessModel_IsUnchanged()
         {
-            View.SelectRuntimeMenu.Received().Enabled = true;
+            View.ProcessModel.DidNotReceiveWithAnyArgs().SelectedItem = null;
+        }
+
+        [Test]
+        public void DomainUsage_IsUnchanged()
+        {
+            View.DomainUsage.DidNotReceiveWithAnyArgs().SelectedItem = null;
         }
 
         [Test]

--- a/src/tests/Presenters/Main/WhenTestsAreUnloaded.cs
+++ b/src/tests/Presenters/Main/WhenTestsAreUnloaded.cs
@@ -83,12 +83,6 @@ namespace NUnit.Gui.Presenters.Main
         }
 
         [Test]
-        public void SelectRuntimeMenu_IsDisabled()
-        {
-            View.SelectRuntimeMenu.Received().Enabled = false;
-        }
-
-        [Test]
         public void RecentProjects_IsEnabled()
         {
             View.RecentProjectsMenu.Received().Enabled = true;

--- a/src/tests/Views/MainFormTests.cs
+++ b/src/tests/Views/MainFormTests.cs
@@ -1,0 +1,75 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Linq;
+using NUnit.Framework;
+using NUnit.UiKit.Elements;
+
+namespace NUnit.Gui.Views
+{
+    public class MainFormTests
+    {
+        private IMainView _view;
+
+        [SetUp]
+        public void CreateView()
+        {
+            _view = new MainForm();
+        }
+
+        [Test]
+        public void SelectedRuntimeTest()
+        {
+            var selectedRuntime = _view.SelectedRuntime as CheckedMenuGroup;
+
+            Assert.NotNull(selectedRuntime, "SelectedRuntime not set properly");
+            Assert.NotNull(selectedRuntime.TopMenu, "TopMenu is not set");
+            Assert.That(selectedRuntime.MenuItems.Select((p) => p.Text), Is.EqualTo(new string[] { "Default" }));
+            Assert.That(selectedRuntime.MenuItems.Select((p) => p.Tag), Is.EqualTo(new string[] { "DEFAULT" }));
+        }
+
+        [Test]
+        public void ProcessModelTest()
+        {
+            var processModel = _view.ProcessModel as CheckedMenuGroup;
+
+            Assert.NotNull(processModel, "ProcessModel not set properly");
+            Assert.That(processModel.MenuItems.Select((p) => p.Text),
+                Is.EqualTo(new string[] { "Default", "InProcess", "Single", "Multiple" }));
+            Assert.That(processModel.MenuItems.Select((p) => p.Tag),
+                Is.EqualTo(new string[] { "DEFAULT", "InProcess", "Single", "Multiple" }));
+        }
+
+        [Test]
+        public void DomainUsageTest()
+        {
+            var domainUsage = _view.DomainUsage as CheckedMenuGroup;
+
+            Assert.NotNull(domainUsage, "DomainUsage not set properly");
+            Assert.That(domainUsage.MenuItems.Select((p) => p.Text),
+                Is.EqualTo(new string[] { "Default", "Single", "Multiple" }));
+            Assert.That(domainUsage.MenuItems.Select((p) => p.Tag),
+                Is.EqualTo(new string[] { "DEFAULT", "Single", "Multiple" }));
+        }
+    }
+}

--- a/src/tests/nunit-gui.tests.csproj
+++ b/src/tests/nunit-gui.tests.csproj
@@ -55,10 +55,12 @@
   <ItemGroup>
     <Compile Include="Model\ResultNodeTests.cs" />
     <Compile Include="Model\ResultStateTests.cs" />
-    <Compile Include="Model\TestModelTests.cs" />
+    <Compile Include="Model\TestModelAssemblyTests.cs" />
+    <Compile Include="Model\TestModelPackageTests.cs" />
     <Compile Include="Model\TestSelectionTests.cs" />
     <Compile Include="Model\TestNodeTests.cs" />
     <Compile Include="Presenters\AddinsPresenterTests.cs" />
+    <Compile Include="Presenters\Main\PackageSettingsTests.cs" />
     <Compile Include="Presenters\Main\WhenTestsAreReloaded.cs" />
     <Compile Include="Presenters\TestGroupTests.cs" />
     <Compile Include="Presenters\StatusBarPresenterTests.cs" />
@@ -84,6 +86,7 @@
     <Compile Include="Presenters\UserSettingsFake.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Views\CommonViewTests.cs" />
+    <Compile Include="Views\MainFormTests.cs" />
     <Compile Include="XmlRtfConverterTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #154 

I'm pretty sure this isn't the last word on the subject, especially WRT the UI. However, it works and is ready for code review and merging so that people can use the various load settings. I still have to hook up the X86 option, but I thought it should start getting reviewed.

After discussing putting it elsewhere, I ended up leaving all three menu items on the File menu. The Process menu is invisible until after a test is loaded. Right now none of the three (Selected Runtime, ProcessModel and DomainUsage actually cause a reload. When you change one you get asked if you want to reload now. You can say no and go back to change another one. However, if it looks like that will happen often, we might want to put all of these settings into a dialog. Main thing for now is that they actually should work!

Also did some cleanup of the UiKit assembly, removing some of the exposure of internal windows forms handles. It's not all gone yet, however.