### PR TITLE
Back out text progress notices from ProgressBar

### DIFF
--- a/src/nunit-gui/Presenters/ProgressBarPresenter.cs
+++ b/src/nunit-gui/Presenters/ProgressBarPresenter.cs
@@ -85,10 +85,10 @@ namespace NUnit.Gui.Presenters
                 }
         }
 
-        private void UpdateProgress(ResultNode result)
+        private void UpdateProgress(TestNode result)
         {
             if (!result.IsSuite)
-                _progressBar.AddStatus(result.Outcome.Status);
+                _progressBar.Progress++;
         }
     }
 }

--- a/src/nunit-gui/Views/MainForm.Designer.cs
+++ b/src/nunit-gui/Views/MainForm.Designer.cs
@@ -718,7 +718,7 @@ namespace NUnit.Gui.Views
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage2);
-            this.tabControl1.Location = new System.Drawing.Point(0, 8);
+            this.tabControl1.Location = new System.Drawing.Point(0, 2);
             this.tabControl1.Margin = new System.Windows.Forms.Padding(2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;

--- a/src/nunit-gui/Views/ProgressBarView.Designer.cs
+++ b/src/nunit-gui/Views/ProgressBarView.Designer.cs
@@ -29,7 +29,6 @@
         private void InitializeComponent()
         {
             this.testProgressBar = new NUnit.UiKit.Controls.NUnitProgressBar();
-            this.testStatusesLabel = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // testProgressBar
@@ -41,21 +40,11 @@
             this.testProgressBar.Status = NUnit.UiKit.Controls.TestProgressBarStatus.Success;
             this.testProgressBar.TabIndex = 0;
             // 
-            // testStatusesLabel
-            // 
-            this.testStatusesLabel.AutoSize = true;
-            this.testStatusesLabel.Dock = System.Windows.Forms.DockStyle.Top;
-            this.testStatusesLabel.Location = new System.Drawing.Point(0, 0);
-            this.testStatusesLabel.Name = "testStatusesLabel";
-            this.testStatusesLabel.Size = new System.Drawing.Size(0, 13);
-            this.testStatusesLabel.TabIndex = 1;
-            // 
             // ProgressBarView
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.testProgressBar);
-            this.Controls.Add(this.testStatusesLabel);
             this.Name = "ProgressBarView";
             this.Size = new System.Drawing.Size(239, 61);
             this.ResumeLayout(false);

--- a/src/tests/Presenters/ProgressBarPresenterTests.cs
+++ b/src/tests/Presenters/ProgressBarPresenterTests.cs
@@ -97,23 +97,23 @@ namespace NUnit.Gui.Presenters
         }
 
         [Test]
-        public void WhenTestCaseCompletes_TestStatusIsSentToProgressBar()
+        public void WhenTestCaseCompletes_ProgressIsIncremented()
         {
             var result = new ResultNode("<test-case id='1'/>");
 
             _model.TestFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.TestFinished, result));
 
-            _view.Received().AddStatus(TestStatus.Passed);
+            _view.Received().Progress++;
         }
 
         [Test]
-        public void WhenTestSuiteCompletes_TestStatusIsNotSentToProgressBar()
+        public void WhenTestSuiteCompletes_ProgressIsNotIncremented()
         {
             var result = new ResultNode("<test-suite id='1'/>");
 
             _model.SuiteFinished += Raise.Event<TestResultEventHandler>(new TestResultEventArgs(TestAction.SuiteFinished, result));
 
-            _view.DidNotReceive().AddStatus(Arg.Any<TestStatus>());
+            _view.DidNotReceive().Progress++;
         }
 
         //[Test]


### PR DESCRIPTION
See comment on issue #75 as to why this is being backed out.

@immeraufdemhund In addtion to my comments on the issue, I noticed in looking at the code that you have the view referencing the model, which breaks the WPF pattern, especially if we want to substitute different views at any time. This is an easy mistake to make if the components are all in the same assembly, so maybe we need some separation.