### PR TITLE
Multiple assert support

### DIFF
--- a/nunit-gui.sln
+++ b/nunit-gui.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "demo-assembly", "src\demo-assembly\demo-assembly.csproj", "{03C3F9EC-FB25-46C0-8F0D-17A0C6E60E9F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +48,10 @@ Global
 		{2E368281-3BA8-4050-B05E-0E0E43F8F446}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E368281-3BA8-4050-B05E-0E0E43F8F446}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2E368281-3BA8-4050-B05E-0E0E43F8F446}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03C3F9EC-FB25-46C0-8F0D-17A0C6E60E9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03C3F9EC-FB25-46C0-8F0D-17A0C6E60E9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03C3F9EC-FB25-46C0-8F0D-17A0C6E60E9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03C3F9EC-FB25-46C0-8F0D-17A0C6E60E9F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/demo-assembly/ApartmentTests.cs
+++ b/src/demo-assembly/ApartmentTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+    [Apartment(ApartmentState.STA)]
+    public class FixtureWithApartmentAttributeOnClass
+    {
+        [Test]
+        public void TestMethodInSTAFixture()
+        {
+            Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA));
+        }
+    }
+
+    public class FixtureWithApartmentAttributeOnMethod
+    {
+        [Test, Apartment(ApartmentState.STA)]
+        public void TestMethodInSTA()
+        {
+            Assert.That(Thread.CurrentThread.GetApartmentState(), Is.EqualTo(ApartmentState.STA));
+        }
+    }
+}

--- a/src/demo-assembly/App.config
+++ b/src/demo-assembly/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="test.setting" value="54321"/>
+  </appSettings>
+</configuration>

--- a/src/demo-assembly/AsyncTests.cs
+++ b/src/demo-assembly/AsyncTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+	public class AsyncTests
+	{
+		[Test, ExpectError]
+		public async void AsyncVoidTestIsInvalid()
+		{
+            var result = await ReturnOne();
+
+            Assert.AreEqual(1, result);
+		}
+
+		[Test, ExpectPass]
+		public async Task AsyncTaskTestSucceeds()
+		{
+			var result = await ReturnOne();
+
+			Assert.AreEqual(1, result);
+		}
+
+		[Test, ExpectFailure]
+		public async Task AsyncTaskTestFails()
+		{
+			var result = await ReturnOne();
+
+			Assert.AreEqual(2, result);
+		}
+
+		[Test, ExpectError]
+		public async Task AsyncTaskTestThrowsException()
+		{
+			await ThrowException();
+
+			Assert.Fail("Should never get here");
+		}
+
+		[TestCase(ExpectedResult = 1), ExpectPass]
+		public async Task<int> AsyncTaskWithResultSucceeds()
+		{
+			return await ReturnOne();
+		}
+
+		[TestCase(ExpectedResult = 2), ExpectFailure]
+		public async Task<int> AsyncTaskWithResultFails()
+		{
+			return await ReturnOne();
+		}
+
+        [TestCase(ExpectedResult = 0), ExpectError]
+		public async Task<int> AsyncTaskWithResultThrowsException()
+		{
+			return await ThrowException();
+		}
+
+		private static Task<int> ReturnOne()
+		{
+			return Task.Run(() => 1);
+		}
+
+		private static Task<int> ThrowException()
+		{
+			return Task.Run(() =>
+			{
+				throw new InvalidOperationException();
+#pragma warning disable 162
+                return 1;
+#pragma warning restore 162
+            });
+		}
+	}
+}

--- a/src/demo-assembly/ConfigFileTests.cs
+++ b/src/demo-assembly/ConfigFileTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Configuration;
+using System.IO;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+    [ExpectPass]
+    public class ConfigFileTests
+    {
+        [Test]
+        public static void ProperConfigFileIsUsed()
+        {
+            var expectedPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "NUnit3TestDemo.dll.config");
+            Assert.That(expectedPath, Is.EqualTo(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile));
+        }
+
+        [Test]
+        public static void CanReadConfigFile()
+        {
+            Assert.That(ConfigurationManager.AppSettings.Get("test.setting"), Is.EqualTo("54321"));
+        }
+
+    }
+}

--- a/src/demo-assembly/ExpectedOutcomeAttributes.cs
+++ b/src/demo-assembly/ExpectedOutcomeAttributes.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+    public class ExpectPassAttribute : PropertyAttribute
+    {
+        public ExpectPassAttribute() : base("Expect", "Pass") { }
+    }
+
+
+    public class ExpectFailureAttribute : PropertyAttribute
+    {
+        public ExpectFailureAttribute() : base("Expect", "Failure") { }
+    }
+
+    public class ExpectWarningAttribute : PropertyAttribute
+    {
+        public ExpectWarningAttribute() : base("Expect", "Warning") { }
+    }
+
+    public class ExpectIgnoreAttribute : PropertyAttribute
+    {
+        public ExpectIgnoreAttribute() : base("Expect", "Ignore") { }
+    }
+
+    public class ExpectSkipAttribute : PropertyAttribute
+    {
+        public ExpectSkipAttribute() : base("Expect", "Skipped") { }
+    }
+
+    public class ExpectErrorAttribute : PropertyAttribute
+    {
+        public ExpectErrorAttribute() : base("Expect", "Error") { }
+    }
+
+    public class ExpectInconclusiveAttribute : PropertyAttribute
+    {
+        public ExpectInconclusiveAttribute() : base("Expect", "Inconclusive") { }
+    }
+
+    public class ExpectMixedAttribute : PropertyAttribute
+    {
+        public ExpectMixedAttribute() : base("Expect", "Mixed") { }
+    }
+}

--- a/src/demo-assembly/GenericTests.cs
+++ b/src/demo-assembly/GenericTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+    [TestFixture(typeof(int))]
+    public class GenericTests<T>
+    {
+        [Test, ExpectPass]
+        public void TestIt() { }
+    }
+
+    [ExpectPass]
+    [TestFixture(typeof(ArrayList))]
+    [TestFixture(typeof(List<int>))]
+    public class GenericTests_IList<TList> where TList : IList, new()
+    {
+        private IList list;
+
+        [SetUp]
+        public void CreateList()
+        {
+            this.list = new TList();
+        }
+
+        [Test]
+        public void CanAddToList()
+        {
+            list.Add(1); list.Add(2); list.Add(3);
+            Assert.AreEqual(3, list.Count);
+        }
+    }
+}

--- a/src/demo-assembly/InheritedTestTests.cs
+++ b/src/demo-assembly/InheritedTestTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+    public abstract class InheritedTestBaseClass
+    {
+        [Test]
+        public void TestInBaseClass()
+        {
+        }
+    }
+
+    public class InheritedTestDerivedClass : InheritedTestBaseClass
+    {
+    }
+}

--- a/src/demo-assembly/OneTimeSetUpTests.cs
+++ b/src/demo-assembly/OneTimeSetUpTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+    [TestFixture, ExpectPass]
+    public class OneTimeSetUpTests
+    {
+        int SetUpCount;
+        int TearDownCount;
+
+        [OneTimeSetUp]
+        public void BeforeTests()
+        {
+            Assert.That(SetUpCount, Is.EqualTo(0));
+            Assert.That(TearDownCount, Is.EqualTo(0));
+            SetUpCount++;
+        }
+
+        [OneTimeTearDown]
+        public void AfterTests()
+        {
+            Assert.That(SetUpCount, Is.EqualTo(1), "Unexpected error");
+            Assert.That(TearDownCount, Is.EqualTo(0));
+            TearDownCount++;
+        }
+
+        [Test]
+        public void Test1()
+        {
+            Assert.That(SetUpCount, Is.EqualTo(1));
+            Assert.That(TearDownCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Test2()
+        {
+            Assert.That(SetUpCount, Is.EqualTo(1));
+            Assert.That(TearDownCount, Is.EqualTo(0));
+        }
+    }
+}

--- a/src/demo-assembly/ParameterizedTests.cs
+++ b/src/demo-assembly/ParameterizedTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Interfaces;
+
+namespace NUnitTestDemo
+{
+    public class ParameterizedTests
+    {
+        [ExpectPass]
+        [TestCase(2, 2, 4)]
+        [TestCase(0, 5, 5)]
+        [TestCase(31, 11, 42)]
+        public void TestCaseSucceeds(int a, int b, int sum)
+        {
+            Assert.That(a + b, Is.EqualTo(sum));
+        }
+
+        [ExpectPass]
+        [TestCase(2, 2, ExpectedResult = 4)]
+        [TestCase(0, 5, ExpectedResult = 5)]
+        [TestCase(31, 11, ExpectedResult = 42)]
+        public int TestCaseSucceeds_Result(int a, int b)
+        {
+            return a + b;
+        }
+
+        [ExpectFailure]
+        [TestCase(31, 11, 99)]
+        public void TestCaseFails(int a, int b, int sum)
+        {
+            Assert.That(a + b, Is.EqualTo(sum));
+        }
+
+        [ExpectWarning]
+        [TestCase(31, 11, 99)]
+        public void TestCaseWarns(int a, int b, int sum)
+        {
+            Warn.Unless(a + b, Is.EqualTo(sum));
+        }
+
+        [ExpectWarning]
+        [TestCase(31, 11, 99)]
+        public void TestCaseWarnsThreeTimes(int a, int b, int answer)
+        {
+            Warn.Unless(a + b, Is.EqualTo(answer), "Bad sum");
+            Warn.Unless(a - b, Is.EqualTo(answer), "Bad difference");
+            Warn.Unless(a * b, Is.EqualTo(answer), "Bad product");
+        }
+
+        [TestCase(31, 11, ExpectedResult = 99), ExpectFailure]
+        public int TestCaseFails_Result(int a, int b)
+        {
+            return a + b;
+        }
+
+        [TestCase(31, 11), ExpectInconclusive]
+        public void TestCaseIsInconclusive(int a, int b)
+        {
+            Assert.Inconclusive("Inconclusive test case");
+        }
+
+        [Ignore("Ignored test"), ExpectIgnore]
+        [TestCase(31, 11)]
+        public void TestCaseIsIgnored_Attribute(int a, int b)
+        {
+        }
+
+        [TestCase(31, 11, Ignore = "Ignoring this"), ExpectIgnore]
+        public void TestCaseIsIgnored_Property(int a, int b)
+        {
+        }
+
+        [TestCase(31, 11), ExpectIgnore]
+        public void TestCaseIsIgnored_Assert(int a, int b)
+        {
+            Assert.Ignore("Ignoring this test case");
+        }
+
+        [TestCase(31, 11, ExcludePlatform="NET"), ExpectSkip]
+        public void TestCaseIsSkipped_Property(int a, int b)
+        {
+        }
+
+        [Platform(Exclude = "NET"), ExpectSkip]
+        [TestCase(31, 11)]
+        public void TestCaseIsSkipped_Attribute(int a, int b)
+        {
+        }
+
+        [Explicit, ExpectSkip]
+        [TestCase(31, 11)]
+        public void TestCaseIsExplicit(int a, int b)
+        {
+        }
+
+        [TestCase(31, 11), ExpectError]
+        public void TestCaseThrowsException(int a, int b)
+        {
+            throw new Exception("Exception from test case");
+        }
+
+        [TestCase(42, TestName="AlternateTestName"), ExpectPass]
+        public void TestCaseWithAlternateName(int x)
+        {
+        }
+
+        [TestCase(42, TestName="NameWithSpecialChar->Here")]
+        public void TestCaseWithSpecialCharInName(int x)
+        {
+        }
+
+        [Test]
+        public void TestCaseWithRandomParameter([Random(1)] int x)
+        {
+        }
+
+#if false // Test for issue #144
+        [MyTestCase]
+        public void TestCaseWithBadTestBuilder(string baz)
+        {
+            Assert.That(baz, Is.EqualTo("baz"));
+        }
+
+        [AttributeUsage(AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
+        class MyTestCaseAttribute : Attribute, ITestBuilder
+        {
+            public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
+            {
+                throw new InvalidOperationException("This is intentionally broken");
+            }
+        }
+#endif
+    }
+}

--- a/src/demo-assembly/Properties/AssemblyInfo.cs
+++ b/src/demo-assembly/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NUnitTestDemo")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NUnitTestDemo")]
+[assembly: AssemblyCopyright("Copyright © Charlie Poole 2011-2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3ef6f2d9-6425-430b-9a70-83b63087f35a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/demo-assembly/SetUpFixtureTests.cs
+++ b/src/demo-assembly/SetUpFixtureTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnitTestDemo.SetUpFixture
+{
+    [SetUpFixture]
+    public class SetUpFixture
+    {
+        public static int SetUpCount;
+        public static int TearDownCount;
+
+        [OneTimeSetUp]
+        public void BeforeTests()
+        {
+            Assert.That(SetUpCount, Is.EqualTo(0));
+            SetUpCount++;
+        }
+
+        [OneTimeTearDown]
+        public void AfterTests()
+        {
+            Assert.That(TearDownCount, Is.EqualTo(0));
+            TearDownCount++;
+        }
+    }
+
+    [TestFixture, ExpectPass]
+    public class TestFixture1
+    {
+        [Test]
+        public void Test1()
+        {
+            Assert.That(SetUpFixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(SetUpFixture.TearDownCount, Is.EqualTo(0));
+        }
+    }
+
+    [TestFixture, ExpectPass]
+    public class TestFixture2
+    {
+        [Test]
+        public void Test2()
+        {
+            Assert.That(SetUpFixture.SetUpCount, Is.EqualTo(1));
+            Assert.That(SetUpFixture.TearDownCount, Is.EqualTo(0));
+        }
+    }
+}

--- a/src/demo-assembly/SimpleTests.cs
+++ b/src/demo-assembly/SimpleTests.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+    public class SimpleTests
+    {
+        [Test, ExpectPass]
+        public void TestSucceeds()
+        {
+            Console.WriteLine("Simple test running");
+            Assert.That(2 + 2, Is.EqualTo(4));
+        }
+
+        [Test, ExpectPass]
+        public void TestSucceeds_Message()
+        {
+            Assert.That(2 + 2, Is.EqualTo(4));
+            Assert.Pass("Simple arithmetic!");
+        }
+
+        [Test, ExpectFailure]
+        public void TestFails()
+        {
+            Assert.That(2 + 2, Is.EqualTo(5));
+        }
+
+        [Test, ExpectWarning]
+        public void TestWarns()
+        {
+            Assert.Warn("This is a warning");
+        }
+
+        [Test, ExpectWarning]
+        public void TestWarnsThreeTimes()
+        {
+            Assert.Warn("Warning 1");
+            Assert.Warn("Warning 2");
+            Assert.Warn("Warning 3");
+        }
+
+        [Test, ExpectFailure]
+        public void TestWithThreeFailures()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.Fail("Failure 1");
+                Assert.That(2 + 2, Is.EqualTo(5), "Failure 2");
+                Assert.That(42, Is.GreaterThan(99), "Failure 3");
+            });
+        }
+
+        [Test, ExpectFailure]
+        public void TestWithTwoFailuresAndAnError()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(2 + 2, Is.EqualTo(5));
+                Assert.That(42, Is.GreaterThan(99));
+                throw new Exception("Throwing after two failures");
+            });
+        }
+
+        [Test, ExpectFailure]
+        public void TestWithFailureAndWarning()
+        {
+            Assert.Warn("WARNING!");
+            Assert.Fail("FAILING!");
+        }
+
+        [Test, ExpectFailure]
+        public void TestWithTwoFailuresAndAWarning()
+        {
+            Warn.Unless(2 + 2 == 5, "Math is too hard!");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(2 + 2, Is.EqualTo(5));
+                Assert.That(42, Is.GreaterThan(99));
+            });
+        }
+
+        [Test, ExpectFailure]
+        public void TestFails_StringEquality()
+        {
+            Assert.That("Hello" + "World" + "!", Is.EqualTo("Hello World!"));
+        }
+
+        [Test, ExpectInconclusive]
+        public void TestIsInconclusive()
+        {
+            Assert.Inconclusive("Testing");
+        }
+
+        [Test, Ignore("Ignoring this test deliberately"), ExpectIgnore]
+        public void TestIsIgnored_Attribute()
+        {
+        }
+
+        [Test, ExpectIgnore]
+        public void TestIsIgnored_Assert()
+        {
+            Assert.Ignore("Ignoring this test deliberately");
+        }
+
+        // Since we only run under .NET, test is always excluded
+        [Test, ExpectSkip, Platform("Exclude=\"NET\"")]
+        public void TestIsSkipped_Platform()
+        {
+        }
+
+        [Test, ExpectSkip, Explicit]
+        public void TestIsExplicit()
+        {
+        }
+
+        [Test, ExpectError]
+        public void TestThrowsException()
+        {
+            throw new Exception("Deliberate exception thrown");
+        }
+
+        [Test, ExpectPass]
+        [Property("Priority", "High")]
+        public void TestWithProperty()
+        {
+        }
+
+        [Test, ExpectPass]
+        [Property("Priority", "Low")]
+        [Property("Action", "Ignore")]
+        public void TestWithTwoProperties()
+        {
+        }
+
+        [Test, ExpectPass]
+        [Category("Slow")]
+        public void TestWithCategory()
+        {
+        }
+
+        [Test, ExpectPass]
+        [Category("Slow")]
+        [Category("Data")]
+        public void TestWithTwoCategories()
+        {
+        }
+    }
+}

--- a/src/demo-assembly/TextOutputTests.cs
+++ b/src/demo-assembly/TextOutputTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using System.Diagnostics;
+
+namespace NUnitTestDemo
+{
+    [ExpectPass]
+    public class TextOutputTests
+    {
+        [Test]
+        public void WriteToConsole()
+        {
+            Console.WriteLine("This is Console line 1");
+            Console.WriteLine("This is Console line 2\nThis is Console line 3");
+        }
+
+        [Test]
+        public void WriteToError()
+        {
+            Console.Error.WriteLine("This is Error line 1");
+            Console.Error.WriteLine("This is Error line 2\nThis is Error line 3");
+        }
+
+        [Test]
+        public void WriteToTestContext()
+        {
+            TestContext.WriteLine("Line 1 to TestContext");
+            TestContext.WriteLine("Line 2 to TestContext\nLine 3 to TestContext");
+        }
+
+        [Test]
+        public void WriteToTestContextOut()
+        {
+            TestContext.Out.WriteLine("Line 1 to TestContext.Out");
+            TestContext.Out.WriteLine("Line 2 to TestContext.Out\nLine 3 to TestContext.Out");
+        }
+
+        [Test]
+        public void WriteToTestContextError()
+        {
+            TestContext.Error.WriteLine("Line 1 to TestContext.Error");
+            TestContext.Error.WriteLine("Line 2 to TestContext.Error\nLine 3 to TestContext.Error");
+        }
+
+        [Test]
+        public void WriteToTestContextProgress()
+        {
+            TestContext.Progress.WriteLine("Line 1 to TestContext.Progress");
+            TestContext.Progress.WriteLine("Line 2 to TestContext.Progress\nLine 3 to TestContext.Progress");
+        }
+
+        [Test]
+        public void WriteToTrace()
+        {
+            Trace.Write("This is Trace line 1");
+            Trace.Write("This is Trace line 2");
+            Trace.Write("This is Trace line 3");
+        }
+
+        [Test, Description("Displays various settings for verification")]
+        public void DisplayTestSettings()
+        {
+            Console.WriteLine("CurrentDirectory={0}", Environment.CurrentDirectory);
+            Console.WriteLine("BasePath={0}", AppDomain.CurrentDomain.BaseDirectory);
+            Console.WriteLine("PrivateBinPath={0}", AppDomain.CurrentDomain.SetupInformation.PrivateBinPath);
+            Console.WriteLine("WorkDirectory={0}", TestContext.CurrentContext.WorkDirectory);
+            Console.WriteLine("DefaultTimeout={0}", NUnit.Framework.Internal.TestExecutionContext.CurrentContext.TestCaseTimeout);
+        }
+
+        [Test]
+        public void DisplayTestParameters()
+        {
+            if (TestContext.Parameters.Count == 0)
+                Console.WriteLine("No TestParameters were passed");
+            else
+            foreach (var name in TestContext.Parameters.Names)
+                Console.WriteLine("Parameter: {0} = {1}", name, TestContext.Parameters.Get(name));
+        }
+    }
+}

--- a/src/demo-assembly/Theories.cs
+++ b/src/demo-assembly/Theories.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+    public class Theories
+    {
+        [Datapoints]
+        int[] data = new int[] { 0, 1, 42 };
+
+        [Theory, ExpectPass]
+        public void Theory_AllCasesSucceed(int a, int b)
+        {
+            Assert.That(a + b, Is.EqualTo(b + a));
+        }
+
+        [Theory, ExpectMixed]
+        public void Theory_SomeCasesAreInconclusive(int a, int b)
+        {
+            Assume.That(b != 0);
+        }
+
+        [Theory, ExpectMixed]
+        public void Theory_SomeCasesFail(int a, int b)
+        {
+            Assert.That(b != 0);
+        }
+    }
+}

--- a/src/demo-assembly/demo-assembly.csproj
+++ b/src/demo-assembly/demo-assembly.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{03C3F9EC-FB25-46C0-8F0D-17A0C6E60E9F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NUnitTestDemo</RootNamespace>
+    <AssemblyName>demo-assembly</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ApartmentTests.cs" />
+    <Compile Include="AsyncTests.cs" />
+    <Compile Include="ConfigFileTests.cs" />
+    <Compile Include="ExpectedOutcomeAttributes.cs" />
+    <Compile Include="GenericTests.cs" />
+    <Compile Include="InheritedTestTests.cs" />
+    <Compile Include="TextOutputTests.cs" />
+    <Compile Include="ParameterizedTests.cs" />
+    <Compile Include="SetUpFixtureTests.cs" />
+    <Compile Include="SimpleTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="OneTimeSetUpTests.cs" />
+    <Compile Include="Theories.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/demo-assembly/packages.config
+++ b/src/demo-assembly/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+</packages>

--- a/src/nunit-gui/Model/ResultNode.cs
+++ b/src/nunit-gui/Model/ResultNode.cs
@@ -49,7 +49,7 @@ namespace NUnit.Gui.Model
                 : 0.0;
         }
 
-        public ResultNode(string xmlText) : base(XmlHelper.CreateXmlNode(xmlText)) { }
+        public ResultNode(string xmlText) : this(XmlHelper.CreateXmlNode(xmlText)) { }
 
         #endregion
 

--- a/src/nunit-gui/Model/ResultNode.cs
+++ b/src/nunit-gui/Model/ResultNode.cs
@@ -35,19 +35,9 @@ namespace NUnit.Gui.Model
     /// </summary>
     public class ResultNode : TestNode
     {
-        #region Construction and Initialization
+        #region Constructors
 
         public ResultNode(XmlNode xmlNode) : base(xmlNode)
-        {
-            InitializeResultProperties();
-        }
-
-        public ResultNode(string xmlText) : base(xmlText)
-        {
-            InitializeResultProperties();
-        }
-
-        private void InitializeResultProperties()
         {
             Status = GetStatus();
             Label = GetAttribute("label");
@@ -59,15 +49,17 @@ namespace NUnit.Gui.Model
                 : 0.0;
         }
 
+        public ResultNode(string xmlText) : base(XmlHelper.CreateXmlNode(xmlText)) { }
+
         #endregion
 
         #region Public Properties
 
-        public TestStatus Status { get; private set; }
-        public string Label { get; private set; }
-        public ResultState Outcome { get; private set; }
-        public int AssertCount { get; private set; }
-        public double Duration { get; private set; }
+        public TestStatus Status { get; }
+        public string Label { get; }
+        public ResultState Outcome { get; }
+        public int AssertCount { get; }
+        public double Duration { get; }
 
         #endregion
 

--- a/src/nunit-gui/Model/TestNode.cs
+++ b/src/nunit-gui/Model/TestNode.cs
@@ -49,25 +49,11 @@ namespace NUnit.Gui.Model
     /// </summary>
     public class TestNode : ITestItem
     {
+        #region Constructors
+
         public TestNode(XmlNode xmlNode)
         {
             Xml = xmlNode;
-
-            InitializeTestProperties();
-        }
-
-        public TestNode(string xmlText)
-        {
-            XmlDocument doc = new XmlDocument();
-            doc.LoadXml(xmlText);
-            Xml = doc.FirstChild;
-
-            InitializeTestProperties();
-        }
-
-        private void InitializeTestProperties()
-        {
-            // Initialize properties that should always be present in a TestNode
             IsSuite = Xml.Name == "test-suite" || Xml.Name == "test-run";
             Id = Xml.GetAttribute("id");
             Name = Xml.GetAttribute("name");
@@ -77,16 +63,20 @@ namespace NUnit.Gui.Model
             RunState = GetRunState();
         }
 
+        public TestNode(string xmlText) : this(XmlHelper.CreateXmlNode(xmlText)) { }
+
+        #endregion
+
         #region Public Properties
 
-        public XmlNode Xml { get; private set; }
-        public bool IsSuite { get; private set; }
-        public string Id { get; private set; }
-        public string Name { get; private set; }
-        public string FullName  { get; private set; }
-        public string Type { get; private set; }
-        public int TestCount { get; private set; }
-        public RunState RunState { get; private set; }
+        public XmlNode Xml { get; }
+        public bool IsSuite { get; }
+        public string Id { get; }
+        public string Name { get; }
+        public string FullName  { get; }
+        public string Type { get; }
+        public int TestCount { get; }
+        public RunState RunState { get; }
 
         private List<TestNode> _children;
         public IList<TestNode> Children

--- a/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
+++ b/src/nunit-gui/Presenters/TestPropertiesPresenter.cs
@@ -166,11 +166,36 @@ namespace NUnit.Gui.Presenters
                 sb.AppendFormat("{0}) {1}\n", ++index, assertion.Status);
                 sb.AppendLine(assertion.Message);
                 if (assertion.StackTrace != null)
-                    sb.AppendLine(assertion.StackTrace);
+                    sb.AppendLine(AdjustStackTrace(assertion.StackTrace));
 
             }
 
             _view.Assertions = sb.ToString();
+        }
+
+        // Some versions of the framework return the stacktrace
+        // without leading spaces, so we add them if needed.
+        // TODO: Make sure this is valid across various cultures.
+        private const string LEADING_SPACES = "   ";
+
+        private static string AdjustStackTrace(string stackTrace)
+        {
+            // Check if no adjustment needed. We assume that all
+            // lines start the same - either with or without spaces.
+            if (stackTrace.StartsWith(LEADING_SPACES))
+                return stackTrace;
+
+            var sr = new StringReader(stackTrace);
+            var sb = new StringBuilder();
+            string line = sr.ReadLine();
+            while (line != null)
+            {
+                sb.Append(LEADING_SPACES);
+                sb.AppendLine(line);
+                line = sr.ReadLine();
+            }
+
+            return sb.ToString();
         }
 
         private void DisplayOutput(ResultNode resultNode)

--- a/src/nunit-gui/Views/MainForm.Designer.cs
+++ b/src/nunit-gui/Views/MainForm.Designer.cs
@@ -769,7 +769,7 @@ namespace NUnit.Gui.Views
             this.propertiesView.FullName = "";
             this.propertiesView.Header = "";
             this.propertiesView.Location = new System.Drawing.Point(2, 2);
-            this.propertiesView.Message = "";
+            this.propertiesView.Assertions = "";
             this.propertiesView.Name = "propertiesView";
             this.propertiesView.Outcome = "";
             this.propertiesView.Output = "";
@@ -778,7 +778,6 @@ namespace NUnit.Gui.Views
             this.propertiesView.RunState = "";
             this.propertiesView.Size = new System.Drawing.Size(337, 332);
             this.propertiesView.SkipReason = "";
-            this.propertiesView.StackTrace = "";
             this.propertiesView.TabIndex = 2;
             this.propertiesView.TestCount = "";
             this.propertiesView.TestType = "";

--- a/src/nunit-gui/Views/TestPropertiesView.Designer.cs
+++ b/src/nunit-gui/Views/TestPropertiesView.Designer.cs
@@ -47,7 +47,6 @@
             this.assertCountLabel = new System.Windows.Forms.Label();
             this.assertCount = new System.Windows.Forms.Label();
             this.messageLabel = new System.Windows.Forms.Label();
-            this.stackTraceLabel = new System.Windows.Forms.Label();
             this.testCount = new System.Windows.Forms.Label();
             this.runStateLabel = new System.Windows.Forms.Label();
             this.testCountLabel = new System.Windows.Forms.Label();
@@ -55,8 +54,7 @@
             this.resultPanel = new System.Windows.Forms.Panel();
             this.output = new NUnit.UiKit.Controls.ExpandingLabel();
             this.outputLabel = new System.Windows.Forms.Label();
-            this.stackTrace = new NUnit.UiKit.Controls.ExpandingLabel();
-            this.message = new NUnit.UiKit.Controls.ExpandingLabel();
+            this.assertions = new NUnit.UiKit.Controls.ExpandingLabel();
             this.testPanel = new System.Windows.Forms.Panel();
             this.fullName = new NUnit.UiKit.Controls.ExpandingLabel();
             this.description = new NUnit.UiKit.Controls.ExpandingLabel();
@@ -222,19 +220,12 @@
             // 
             // messageLabel
             // 
-            this.messageLabel.Location = new System.Drawing.Point(3, 38);
+            this.messageLabel.AutoSize = true;
+            this.messageLabel.Location = new System.Drawing.Point(3, 39);
             this.messageLabel.Name = "messageLabel";
-            this.messageLabel.Size = new System.Drawing.Size(53, 13);
+            this.messageLabel.Size = new System.Drawing.Size(82, 13);
             this.messageLabel.TabIndex = 25;
-            this.messageLabel.Text = "Message:";
-            // 
-            // stackTraceLabel
-            // 
-            this.stackTraceLabel.Location = new System.Drawing.Point(2, 115);
-            this.stackTraceLabel.Name = "stackTraceLabel";
-            this.stackTraceLabel.Size = new System.Drawing.Size(69, 13);
-            this.stackTraceLabel.TabIndex = 27;
-            this.stackTraceLabel.Text = "Stack Trace:";
+            this.messageLabel.Text = "Test Messages:";
             // 
             // testCount
             // 
@@ -277,13 +268,11 @@
             this.resultPanel.Controls.Add(this.outputLabel);
             this.resultPanel.Controls.Add(this.outcomeLabel);
             this.resultPanel.Controls.Add(this.outcome);
-            this.resultPanel.Controls.Add(this.stackTrace);
             this.resultPanel.Controls.Add(this.elapsedTimeLabel);
             this.resultPanel.Controls.Add(this.assertCountLabel);
-            this.resultPanel.Controls.Add(this.stackTraceLabel);
             this.resultPanel.Controls.Add(this.assertCount);
             this.resultPanel.Controls.Add(this.messageLabel);
-            this.resultPanel.Controls.Add(this.message);
+            this.resultPanel.Controls.Add(this.assertions);
             this.resultPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.resultPanel.Location = new System.Drawing.Point(0, 0);
             this.resultPanel.Name = "resultPanel";
@@ -297,7 +286,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.output.BackColor = System.Drawing.Color.LightYellow;
             this.output.Expansion = NUnit.UiKit.Controls.TipWindow.ExpansionStyle.Both;
-            this.output.Location = new System.Drawing.Point(5, 208);
+            this.output.Location = new System.Drawing.Point(5, 203);
             this.output.Name = "output";
             this.output.Size = new System.Drawing.Size(527, 187);
             this.output.TabIndex = 29;
@@ -305,33 +294,22 @@
             // outputLabel
             // 
             this.outputLabel.AutoSize = true;
-            this.outputLabel.Location = new System.Drawing.Point(2, 182);
+            this.outputLabel.Location = new System.Drawing.Point(2, 180);
             this.outputLabel.Name = "outputLabel";
             this.outputLabel.Size = new System.Drawing.Size(42, 13);
             this.outputLabel.TabIndex = 0;
             this.outputLabel.Text = "Output:";
             // 
-            // stackTrace
+            // assertions
             // 
-            this.stackTrace.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.assertions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.stackTrace.BackColor = System.Drawing.Color.LightYellow;
-            this.stackTrace.Expansion = NUnit.UiKit.Controls.TipWindow.ExpansionStyle.Both;
-            this.stackTrace.Location = new System.Drawing.Point(5, 128);
-            this.stackTrace.Name = "stackTrace";
-            this.stackTrace.Size = new System.Drawing.Size(527, 54);
-            this.stackTrace.TabIndex = 28;
-            // 
-            // message
-            // 
-            this.message.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.message.BackColor = System.Drawing.Color.LightYellow;
-            this.message.Expansion = NUnit.UiKit.Controls.TipWindow.ExpansionStyle.Both;
-            this.message.Location = new System.Drawing.Point(5, 51);
-            this.message.Name = "message";
-            this.message.Size = new System.Drawing.Size(527, 58);
-            this.message.TabIndex = 26;
+            this.assertions.BackColor = System.Drawing.Color.LightYellow;
+            this.assertions.Expansion = NUnit.UiKit.Controls.TipWindow.ExpansionStyle.Both;
+            this.assertions.Location = new System.Drawing.Point(3, 57);
+            this.assertions.Name = "assertions";
+            this.assertions.Size = new System.Drawing.Size(527, 114);
+            this.assertions.TabIndex = 26;
             // 
             // testPanel
             // 
@@ -442,9 +420,7 @@
         private System.Windows.Forms.Label assertCountLabel;
         private System.Windows.Forms.Label assertCount;
         private System.Windows.Forms.Label messageLabel;
-        private NUnit.UiKit.Controls.ExpandingLabel message;
-        private System.Windows.Forms.Label stackTraceLabel;
-        private NUnit.UiKit.Controls.ExpandingLabel stackTrace;
+        private NUnit.UiKit.Controls.ExpandingLabel assertions;
         private System.Windows.Forms.Label testCount;
         private System.Windows.Forms.Label runStateLabel;
         private System.Windows.Forms.Label testCountLabel;

--- a/src/nunit-gui/Views/TestPropertiesView.Designer.cs
+++ b/src/nunit-gui/Views/TestPropertiesView.Designer.cs
@@ -306,6 +306,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.assertions.BackColor = System.Drawing.Color.LightYellow;
             this.assertions.Expansion = NUnit.UiKit.Controls.TipWindow.ExpansionStyle.Both;
+            this.assertions.Font = new System.Drawing.Font("Lucida Console", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.assertions.Location = new System.Drawing.Point(3, 57);
             this.assertions.Name = "assertions";
             this.assertions.Size = new System.Drawing.Size(527, 114);

--- a/src/nunit-gui/Views/TestPropertiesView.Designer.cs
+++ b/src/nunit-gui/Views/TestPropertiesView.Designer.cs
@@ -139,6 +139,7 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.properties.BackColor = System.Drawing.Color.LightYellow;
+            this.properties.Font = new System.Drawing.Font("Lucida Console", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.properties.Location = new System.Drawing.Point(6, 128);
             this.properties.Name = "properties";
             this.properties.Size = new System.Drawing.Size(526, 98);
@@ -286,6 +287,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.output.BackColor = System.Drawing.Color.LightYellow;
             this.output.Expansion = NUnit.UiKit.Controls.TipWindow.ExpansionStyle.Both;
+            this.output.Font = new System.Drawing.Font("Lucida Console", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.output.Location = new System.Drawing.Point(5, 203);
             this.output.Name = "output";
             this.output.Size = new System.Drawing.Size(527, 187);

--- a/src/nunit-gui/Views/TestPropertiesView.cs
+++ b/src/nunit-gui/Views/TestPropertiesView.cs
@@ -52,8 +52,7 @@ namespace NUnit.Gui.Views
         string Outcome { get; set;  }
         string ElapsedTime { get; set;  }
         string AssertCount { get; set;  }
-        string Message { get; set;  }
-        string StackTrace { get; set;  }
+        string Assertions { get; set;  }
         string Output { get; set; }
     }
 
@@ -155,16 +154,10 @@ namespace NUnit.Gui.Views
             set { InvokeIfRequired(() => { assertCount.Text = value; }); }
         }
 
-        public string Message
+        public string Assertions
         {
-            get { return message.Text; }
-            set { InvokeIfRequired(() => { message.Text = value; }); }
-        }
-
-        public string StackTrace
-        {
-            get { return stackTrace.Text; }
-            set { InvokeIfRequired(() => { stackTrace.Text = value; }); }
+            get { return assertions.Text; }
+            set { InvokeIfRequired(() => { assertions.Text = value; }); }
         }
 
         public string Output

--- a/src/nunit.uikit/Controls/TipWindow.cs
+++ b/src/nunit.uikit/Controls/TipWindow.cs
@@ -29,338 +29,266 @@ using System.Runtime.InteropServices;
 
 namespace NUnit.UiKit.Controls
 {
-	public class TipWindow : Form
-	{
-		/// <summary>
-		/// Direction in which to expand
-		/// </summary>
-		public enum ExpansionStyle
-		{
-			Horizontal,
-			Vertical,
-			Both
-		}
+    public class TipWindow : Form
+    {
+        /// <summary>
+        /// Direction in which to expand
+        /// </summary>
+        public enum ExpansionStyle
+        {
+            Horizontal,
+            Vertical,
+            Both
+        }
 
-		#region Instance Variables
+        #region Instance Variables
 
-		/// <summary>
-		/// Text we are displaying
-		/// </summary>
-		private string tipText;
+        /// <summary>
+        /// The control for which we are showing expanded text
+        /// </summary>
+        private Control _control;
 
-		/// <summary>
-		/// The control for which we are showing expanded text
-		/// </summary>
-		private Control control;
+        /// <summary>
+        /// Timer used for auto-close
+        /// </summary>
+        private System.Windows.Forms.Timer _autoCloseTimer;
 
-		/// <summary>
-		/// Rectangle representing bounds to overlay. For a listbox, this
-		/// is a single item rectangle. For other controls, it is usually
-		/// the entire client area.
-		/// </summary>
-		private Rectangle itemBounds;
+        /// <summary>
+        /// Timer used for mouse leave delay
+        /// </summary>
+        private System.Windows.Forms.Timer _mouseLeaveTimer;
 
-		/// <summary>
-		/// True if we may overlay control or item
-		/// </summary>
-		private bool overlay = true;
-			
-		/// <summary>
-		/// Directions we are allowed to expand
-		/// </summary>
-		private ExpansionStyle expansion = ExpansionStyle.Horizontal;
+        /// <summary>
+        /// Rectangle used to display text
+        /// </summary>
+        private Rectangle _textRect;
 
-		/// <summary>
-		/// Time before automatically closing
-		/// </summary>
-		private int autoCloseDelay = 0;
+        #endregion
 
-		/// <summary>
-		/// Timer used for auto-close
-		/// </summary>
-		private System.Windows.Forms.Timer autoCloseTimer;
+        #region Construction and Initialization
 
-		/// <summary>
-		/// Time to wait for after mouse leaves
-		/// the window or the label before closing.
-		/// </summary>
-		private int mouseLeaveDelay = 300;
+        public TipWindow( Control control )
+        {
+            InitializeComponent();
+            InitControl( control );
 
-		/// <summary>
-		/// Timer used for mouse leave delay
-		/// </summary>
-		private System.Windows.Forms.Timer mouseLeaveTimer;
+            // Note: This causes an error if called on a listbox
+            // with no item as yet selected, therefore, it is handled
+            // differently in the constructor for a listbox.
+            TipText = control.Text;
+        }
 
-		/// <summary>
-		/// Rectangle used to display text
-		/// </summary>
-		private Rectangle textRect;
+        public TipWindow( ListBox listbox, int index )
+        {
+            InitializeComponent();
+            InitControl( listbox );
 
-		/// <summary>
-		/// Indicates whether any clicks should be passed to the underlying control
-		/// </summary>
-		private bool wantClicks = false;
+            ItemBounds = listbox.GetItemRectangle( index );
+            TipText = listbox.Items[ index ].ToString();
+        }
 
-		#endregion
+        private void InitControl( Control control )
+        {
+            _control = control;
+            Owner = control.FindForm();
+            ItemBounds = control.ClientRectangle;
 
-		#region Construction and Initialization
+            ControlBox = false;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            BackColor = Color.LightYellow;
+            FormBorderStyle = FormBorderStyle.None;
+            StartPosition = FormStartPosition.Manual; 			
 
-		public TipWindow( Control control )
-		{
-			InitializeComponent();
-			InitControl( control );
+            Font = control.Font;
+        }
 
-			// Note: This causes an error if called on a listbox
-			// with no item as yet selected, therefore, it is handled
-			// differently in the constructor for a listbox.
-			this.tipText = control.Text;
-		}
+        private void InitializeComponent()
+        {
+            // 
+            // TipWindow
+            // 
+            BackColor = System.Drawing.Color.LightYellow;
+            ClientSize = new System.Drawing.Size(292, 268);
+            ControlBox = false;
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "TipWindow";
+            ShowInTaskbar = false;
+            StartPosition = System.Windows.Forms.FormStartPosition.Manual;
 
-		public TipWindow( ListBox listbox, int index )
-		{
-			InitializeComponent();
-			InitControl( listbox );
+        }
 
-			this.itemBounds = listbox.GetItemRectangle( index );
-			this.tipText = listbox.Items[ index ].ToString();
-		}
+        protected override void OnLoad(System.EventArgs e)
+        {
+            // At this point, further changes to the properties
+            // of the label will have no effect on the tip.
+            Point origin = _control.Parent.PointToScreen( _control.Location );
+            origin.Offset( ItemBounds.Left, ItemBounds.Top );
+            if ( !Overlay )	origin.Offset( 0, ItemBounds.Height );
+            Location = origin;
 
-		private void InitControl( Control control )
-		{
-			this.control = control;
-			this.Owner = control.FindForm();
-			this.itemBounds = control.ClientRectangle;
+            Graphics g = Graphics.FromHwnd( Handle );
+            Screen screen = Screen.FromControl( _control );
+            SizeF layoutArea = new SizeF( screen.WorkingArea.Width - 40, screen.WorkingArea.Height - 40 );
+            if ( Expansion == ExpansionStyle.Vertical )
+                layoutArea.Width = ItemBounds.Width;
+            else if ( Expansion == ExpansionStyle.Horizontal )
+                layoutArea.Height = ItemBounds.Height;
 
-			this.ControlBox = false;
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.BackColor = Color.LightYellow;
-			this.FormBorderStyle = FormBorderStyle.None;
-			this.StartPosition = FormStartPosition.Manual; 			
-
-			this.Font = control.Font;
-		}
-
-		private void InitializeComponent()
-		{
-			// 
-			// TipWindow
-			// 
-			this.BackColor = System.Drawing.Color.LightYellow;
-			this.ClientSize = new System.Drawing.Size(292, 268);
-			this.ControlBox = false;
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "TipWindow";
-			this.ShowInTaskbar = false;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
-
-		}
-
-		protected override void OnLoad(System.EventArgs e)
-		{
-			// At this point, further changes to the properties
-			// of the label will have no effect on the tip.
-			Point origin = control.Parent.PointToScreen( control.Location );
-			origin.Offset( itemBounds.Left, itemBounds.Top );
-			if ( !overlay )	origin.Offset( 0, itemBounds.Height );
-			this.Location = origin;
-
-			Graphics g = Graphics.FromHwnd( Handle );
-			Screen screen = Screen.FromControl( control );
-			SizeF layoutArea = new SizeF( screen.WorkingArea.Width - 40, screen.WorkingArea.Height - 40 );
-			if ( expansion == ExpansionStyle.Vertical )
-				layoutArea.Width = itemBounds.Width;
-			else if ( expansion == ExpansionStyle.Horizontal )
-				layoutArea.Height = itemBounds.Height;
-
-			Size sizeNeeded = Size.Ceiling( g.MeasureString( tipText, Font, layoutArea ) );
+            Size sizeNeeded = Size.Ceiling( g.MeasureString( TipText, Font, layoutArea ) );
 
             // If the needed width is smaller than that of the original label,
             // it can be visually confusing, so we adjust. This can only happen
             // with ExpansionStyle.Both, so we won't get here unless either the
             // height or the width is greater.
-            if (sizeNeeded.Width < itemBounds.Width)
-                sizeNeeded.Width = itemBounds.Width;
+            if (sizeNeeded.Width < ItemBounds.Width)
+                sizeNeeded.Width = ItemBounds.Width;
 
-			this.ClientSize = sizeNeeded;
-			this.Size = sizeNeeded + new Size( 2, 2 );
-			this.textRect = new Rectangle( 1, 1, sizeNeeded.Width, sizeNeeded.Height );
+            ClientSize = sizeNeeded;
+            Size = sizeNeeded + new Size( 2, 2 );
+            _textRect = new Rectangle( 1, 1, sizeNeeded.Width, sizeNeeded.Height );
 
-			// Catch mouse leaving the control
-			control.MouseLeave += new EventHandler( control_MouseLeave );
+            // Catch mouse leaving the control
+            _control.MouseLeave += new EventHandler( control_MouseLeave );
 
-			// Catch the form that holds the control closing
-			control.FindForm().Closed += new EventHandler( control_FormClosed );
+            // Catch the form that holds the control closing
+            _control.FindForm().Closed += new EventHandler( control_FormClosed );
 
-			if ( this.Right > screen.WorkingArea.Right )
-			{
-				this.Left = Math.Max( 
-					screen.WorkingArea.Right - this.Width - 20, 
-					screen.WorkingArea.Left + 20);
-			}
+            if ( Right > screen.WorkingArea.Right )
+            {
+                Left = Math.Max( 
+                    screen.WorkingArea.Right - Width - 20, 
+                    screen.WorkingArea.Left + 20);
+            }
 
-			if ( this.Bottom > screen.WorkingArea.Bottom - 20 )
-			{
-				if ( overlay )
-					this.Top = Math.Max(
-						screen.WorkingArea.Bottom - this.Height - 20,
-						screen.WorkingArea.Top + 20 );
+            if ( Bottom > screen.WorkingArea.Bottom - 20 )
+            {
+                if ( Overlay )
+                    Top = Math.Max(
+                        screen.WorkingArea.Bottom - Height - 20,
+                        screen.WorkingArea.Top + 20 );
 
-				if ( this.Bottom > screen.WorkingArea.Bottom - 20 )
-					this.Height = screen.WorkingArea.Bottom - 20 - this.Top;
+                if ( Bottom > screen.WorkingArea.Bottom - 20 )
+                    Height = screen.WorkingArea.Bottom - 20 - Top;
 
-			}
+            }
 
-			if ( autoCloseDelay > 0 )
-			{
-				autoCloseTimer = new System.Windows.Forms.Timer();
-				autoCloseTimer.Interval = autoCloseDelay;
-				autoCloseTimer.Tick += new EventHandler( OnAutoClose );
-				autoCloseTimer.Start();
-			}
-		}
+            if ( AutoCloseDelay > 0 )
+            {
+                _autoCloseTimer = new System.Windows.Forms.Timer();
+                _autoCloseTimer.Interval = AutoCloseDelay;
+                _autoCloseTimer.Tick += new EventHandler( OnAutoClose );
+                _autoCloseTimer.Start();
+            }
+        }
 
-		#endregion
+        #endregion
 
-		#region Properties
+        #region Properties
 
-		public bool Overlay
-		{
-			get { return overlay; }
-			set { overlay = value; }
-		}
+        public bool Overlay { get; set; }
+        public ExpansionStyle Expansion { get; set; }
+        public int AutoCloseDelay { get; set; }
+        public int MouseLeaveDelay { get; set; }
+        public string TipText { get; set; }
+        public Rectangle ItemBounds { get; set; }
+        public bool WantClicks { get; set; }
 
-		public ExpansionStyle Expansion
-		{
-			get { return expansion; }
-			set { expansion = value; }
-		}
+        #endregion
 
-		public int AutoCloseDelay
-		{
-			get { return autoCloseDelay; }
-			set { autoCloseDelay = value; }
-		}
+        #region Event Handlers
 
-		public int MouseLeaveDelay
-		{
-			get { return mouseLeaveDelay; }
-			set { mouseLeaveDelay = value; }
-		}
+        protected override void OnPaint(System.Windows.Forms.PaintEventArgs e)
+        {
+            base.OnPaint( e );
+                
+            Graphics g = e.Graphics;
+            Rectangle outlineRect = ClientRectangle;
+            outlineRect.Inflate( -1, -1 );
+            g.DrawRectangle( Pens.Black, outlineRect );
+            g.DrawString( TipText, Font, Brushes.Black, _textRect );
+        }
 
-		public string TipText
-		{
-			get { return tipText; }
-			set { tipText = value; }
-		}
+        private void OnAutoClose( object sender, System.EventArgs e )
+        {
+            Close();
+        }
 
-		public Rectangle ItemBounds
-		{
-			get { return itemBounds; }
-			set { itemBounds = value; }
-		}
+        protected override void OnMouseEnter(System.EventArgs e)
+        {
+            if ( _mouseLeaveTimer != null )
+            {
+                _mouseLeaveTimer.Stop();
+                _mouseLeaveTimer.Dispose();
+                System.Diagnostics.Debug.WriteLine( "Entered TipWindow - stopped mouseLeaveTimer" );
+            }
+        }
 
-		public bool WantClicks
-		{
-			get { return wantClicks; }
-			set { wantClicks = value; }
-		}
+        protected override void OnMouseLeave(System.EventArgs e)
+        {
+            if ( MouseLeaveDelay > 0  )
+            {
+                _mouseLeaveTimer = new System.Windows.Forms.Timer();
+                _mouseLeaveTimer.Interval = MouseLeaveDelay;
+                _mouseLeaveTimer.Tick += new EventHandler( OnAutoClose );
+                _mouseLeaveTimer.Start();
+                System.Diagnostics.Debug.WriteLine( "Left TipWindow - started mouseLeaveTimer" );
+            }
+        }
 
-		#endregion
+        /// <summary>
+        /// The form our label is on closed, so we should. 
+        /// </summary>
+        private void control_FormClosed( object sender, System.EventArgs e )
+        {
+            Close();
+        }
 
-		#region Event Handlers
+        /// <summary>
+        /// The mouse left the label. We ignore if we are
+        /// overlaying the label but otherwise start a
+        /// delay for closing the window
+        /// </summary>
+        private void control_MouseLeave( object sender, System.EventArgs e )
+        {
+            if ( MouseLeaveDelay > 0 && !Overlay )
+            {
+                _mouseLeaveTimer = new System.Windows.Forms.Timer();
+                _mouseLeaveTimer.Interval = MouseLeaveDelay;
+                _mouseLeaveTimer.Tick += new EventHandler( OnAutoClose );
+                _mouseLeaveTimer.Start();
+                System.Diagnostics.Debug.WriteLine( "Left Control - started mouseLeaveTimer" );
+            }
+        }
 
-		protected override void OnPaint(System.Windows.Forms.PaintEventArgs e)
-		{
-			base.OnPaint( e );
-				
-			Graphics g = e.Graphics;
-			Rectangle outlineRect = this.ClientRectangle;
-			outlineRect.Inflate( -1, -1 );
-			g.DrawRectangle( Pens.Black, outlineRect );
-			g.DrawString( tipText, Font, Brushes.Black, textRect );
-		}
+        #endregion
+    
+        [DllImport("user32.dll")]
+        static extern uint SendMessage(
+            IntPtr hwnd,
+            int msg,
+            IntPtr wparam,
+            IntPtr lparam
+            );
+    
+        protected override void WndProc(ref Message m)
+        {
+            uint WM_LBUTTONDOWN = 0x201;
+            uint WM_RBUTTONDOWN = 0x204;
+            uint WM_MBUTTONDOWN = 0x207;
 
-		private void OnAutoClose( object sender, System.EventArgs e )
-		{
-			this.Close();
-		}
-
-		protected override void OnMouseEnter(System.EventArgs e)
-		{
-			if ( mouseLeaveTimer != null )
-			{
-				mouseLeaveTimer.Stop();
-				mouseLeaveTimer.Dispose();
-				System.Diagnostics.Debug.WriteLine( "Entered TipWindow - stopped mouseLeaveTimer" );
-			}
-		}
-
-		protected override void OnMouseLeave(System.EventArgs e)
-		{
-			if ( mouseLeaveDelay > 0  )
-			{
-				mouseLeaveTimer = new System.Windows.Forms.Timer();
-				mouseLeaveTimer.Interval = mouseLeaveDelay;
-				mouseLeaveTimer.Tick += new EventHandler( OnAutoClose );
-				mouseLeaveTimer.Start();
-				System.Diagnostics.Debug.WriteLine( "Left TipWindow - started mouseLeaveTimer" );
-			}
-		}
-
-		/// <summary>
-		/// The form our label is on closed, so we should. 
-		/// </summary>
-		private void control_FormClosed( object sender, System.EventArgs e )
-		{
-			this.Close();
-		}
-
-		/// <summary>
-		/// The mouse left the label. We ignore if we are
-		/// overlaying the label but otherwise start a
-		/// delay for closing the window
-		/// </summary>
-		private void control_MouseLeave( object sender, System.EventArgs e )
-		{
-			if ( mouseLeaveDelay > 0 && !overlay )
-			{
-				mouseLeaveTimer = new System.Windows.Forms.Timer();
-				mouseLeaveTimer.Interval = mouseLeaveDelay;
-				mouseLeaveTimer.Tick += new EventHandler( OnAutoClose );
-				mouseLeaveTimer.Start();
-				System.Diagnostics.Debug.WriteLine( "Left Control - started mouseLeaveTimer" );
-			}
-		}
-
-		#endregion
-	
-		[DllImport("user32.dll")]
-		static extern uint SendMessage(
-			IntPtr hwnd,
-			int msg,
-			IntPtr wparam,
-			IntPtr lparam
-			);
-	
-		protected override void WndProc(ref Message m)
-		{
-			uint WM_LBUTTONDOWN = 0x201;
-			uint WM_RBUTTONDOWN = 0x204;
-			uint WM_MBUTTONDOWN = 0x207;
-
-			if ( m.Msg == WM_LBUTTONDOWN || m.Msg == WM_RBUTTONDOWN || m.Msg == WM_MBUTTONDOWN )
-			{	
-				if ( m.Msg != WM_LBUTTONDOWN )
-					this.Close();
-				SendMessage( control.Handle, m.Msg, m.WParam, m.LParam );
-			}
-			else
-			{
-				base.WndProc (ref m);
-			}
-		}
-	}
+            if ( m.Msg == WM_LBUTTONDOWN || m.Msg == WM_RBUTTONDOWN || m.Msg == WM_MBUTTONDOWN )
+            {	
+                if ( m.Msg != WM_LBUTTONDOWN )
+                    Close();
+                SendMessage( _control.Handle, m.Msg, m.WParam, m.LParam );
+            }
+            else
+            {
+                base.WndProc (ref m);
+            }
+        }
+    }
 }

--- a/src/nunit.uikit/Controls/TipWindow.cs
+++ b/src/nunit.uikit/Controls/TipWindow.cs
@@ -177,6 +177,13 @@ namespace NUnit.UiKit.Controls
 
 			Size sizeNeeded = Size.Ceiling( g.MeasureString( tipText, Font, layoutArea ) );
 
+            // If the needed width is smaller than that of the original label,
+            // it can be visually confusing, so we adjust. This can only happen
+            // with ExpansionStyle.Both, so we won't get here unless either the
+            // height or the width is greater.
+            if (sizeNeeded.Width < itemBounds.Width)
+                sizeNeeded.Width = itemBounds.Width;
+
 			this.ClientSize = sizeNeeded;
 			this.Size = sizeNeeded + new Size( 2, 2 );
 			this.textRect = new Rectangle( 1, 1, sizeNeeded.Width, sizeNeeded.Height );

--- a/src/nunit.uikit/Controls/TipWindow.cs
+++ b/src/nunit.uikit/Controls/TipWindow.cs
@@ -31,6 +31,16 @@ namespace NUnit.UiKit.Controls
 {
     public class TipWindow : Form
     {
+        // Margin of screen, used to limit TipWindow expansion
+        private const int SCREEN_EDGE = 20;
+        private const int SCREEN_MARGIN = 2 * SCREEN_EDGE;
+
+        // Padding to leave inside the TipWindow around the text
+        private const int PADDING_LEFT = 4;
+        private const int PADDING_RIGHT = 4;
+        private const int PADDING_TOP = 4;
+        private const int PADDING_BOTTOM = 4;
+
         /// <summary>
         /// Direction in which to expand
         /// </summary>
@@ -131,7 +141,7 @@ namespace NUnit.UiKit.Controls
 
             Graphics g = Graphics.FromHwnd( Handle );
             Screen screen = Screen.FromControl( _control );
-            SizeF layoutArea = new SizeF( screen.WorkingArea.Width - 40, screen.WorkingArea.Height - 40 );
+            SizeF layoutArea = new SizeF( screen.WorkingArea.Width - SCREEN_MARGIN, screen.WorkingArea.Height - SCREEN_MARGIN );
             if ( Expansion == ExpansionStyle.Vertical )
                 layoutArea.Width = ItemBounds.Width;
             else if ( Expansion == ExpansionStyle.Horizontal )
@@ -147,8 +157,8 @@ namespace NUnit.UiKit.Controls
                 sizeNeeded.Width = ItemBounds.Width;
 
             ClientSize = sizeNeeded;
-            Size = sizeNeeded + new Size( 2, 2 );
-            _textRect = new Rectangle( 1, 1, sizeNeeded.Width, sizeNeeded.Height );
+            Size = sizeNeeded + new Size(PADDING_LEFT + PADDING_RIGHT, PADDING_TOP + PADDING_BOTTOM);
+            _textRect = new Rectangle( PADDING_LEFT, PADDING_TOP, sizeNeeded.Width, sizeNeeded.Height );
 
             // Catch mouse leaving the control
             _control.MouseLeave += new EventHandler( control_MouseLeave );
@@ -159,19 +169,19 @@ namespace NUnit.UiKit.Controls
             if ( Right > screen.WorkingArea.Right )
             {
                 Left = Math.Max( 
-                    screen.WorkingArea.Right - Width - 20, 
-                    screen.WorkingArea.Left + 20);
+                    screen.WorkingArea.Right - Width - SCREEN_EDGE, 
+                    screen.WorkingArea.Left + SCREEN_EDGE);
             }
 
-            if ( Bottom > screen.WorkingArea.Bottom - 20 )
+            if ( Bottom > screen.WorkingArea.Bottom - SCREEN_EDGE)
             {
                 if ( Overlay )
                     Top = Math.Max(
-                        screen.WorkingArea.Bottom - Height - 20,
-                        screen.WorkingArea.Top + 20 );
+                        screen.WorkingArea.Bottom - Height - SCREEN_EDGE,
+                        screen.WorkingArea.Top + SCREEN_EDGE);
 
-                if ( Bottom > screen.WorkingArea.Bottom - 20 )
-                    Height = screen.WorkingArea.Bottom - 20 - Top;
+                if ( Bottom > screen.WorkingArea.Bottom - SCREEN_EDGE)
+                    Height = screen.WorkingArea.Bottom - SCREEN_EDGE - Top;
 
             }
 
@@ -206,8 +216,9 @@ namespace NUnit.UiKit.Controls
                 
             Graphics g = e.Graphics;
             Rectangle outlineRect = ClientRectangle;
-            outlineRect.Inflate( -1, -1 );
-            g.DrawRectangle( Pens.Black, outlineRect );
+            outlineRect.Width--;
+            outlineRect.Height--;
+            g.DrawRectangle(Pens.Black, outlineRect);
             g.DrawString( TipText, Font, Brushes.Black, _textRect );
         }
 


### PR DESCRIPTION
Fixes #140

I combined the two fields Message and StackTrace on the TestPropertiesView and I'm displaying all the results found. The display could use some color or at least bold fonts but I don't want to do it until we resolve whether we are keeping the ExpandingLabel control, because it will be done differently depending on whether we keep or drop it. I did improve the TipWindow display a little bit.

For testing this, if you want to see it work. the NUnit 3 adapter demo program is a good choice as it has a number of tests with multiple failing asserts, failures plus warnings and failures plus errors.